### PR TITLE
Auto map fieldnames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
         	<artifactId>slf4j-api</artifactId>
         	<version>1.6.4</version>
         </dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>10.0.1</version>
+		</dependency>
         
         <!-- test dependencies -->
         <dependency>

--- a/src/main/java/org/sql2o/Query.java
+++ b/src/main/java/org/sql2o/Query.java
@@ -52,6 +52,7 @@ public class Query {
     private NamedParameterStatement statement;
 
     private boolean caseSensitive;
+    private boolean autoDeriveColumnNames;
     
     private final String name;
     private boolean returnGeneratedKeys;
@@ -249,6 +250,16 @@ public class Query {
         return this;
     }
     
+    public boolean isAutoDeriveColumnNames() {
+        return autoDeriveColumnNames;
+    }
+    
+    public Query setAutoDeriveColumnNames(boolean autoDeriveColumnName) {
+    	this.autoDeriveColumnNames = autoDeriveColumnName;
+    	return this;
+    }
+    
+    
     public Connection getConnection(){
         return this.connection;
     }
@@ -259,7 +270,7 @@ public class Query {
 
     public <T> List<T> executeAndFetch(Class returnType){
         List list = new ArrayList();
-        PojoMetadata metadata = new PojoMetadata(returnType, this.isCaseSensitive(), this.getColumnMappings());
+        PojoMetadata metadata = new PojoMetadata(returnType, this.isCaseSensitive(), this.isAutoDeriveColumnNames(), this.getColumnMappings());
         try{
             //java.util.Date st = new java.util.Date();
             long start = System.currentTimeMillis();

--- a/src/main/java/org/sql2o/reflection/PojoMetadata.java
+++ b/src/main/java/org/sql2o/reflection/PojoMetadata.java
@@ -1,11 +1,13 @@
 package org.sql2o.reflection;
 
-import org.sql2o.Sql2oException;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.sql2o.Sql2oException;
+
+import com.google.common.base.CaseFormat;
 
 /**
  * Stores metadata for a POJO.
@@ -15,6 +17,7 @@ public class PojoMetadata {
     private Map<String, Setter> propertySetters;
     private Map<String, Field> fields;
     private boolean caseSensitive;
+    private boolean autoDeriveColumnNames;
     private Class clazz;
     
     private Map<String,String> columnMappings;
@@ -24,8 +27,13 @@ public class PojoMetadata {
     }
 
     public PojoMetadata(Class clazz, boolean caseSensitive, Map<String,String> columnMappings){
+    	this(clazz, caseSensitive, false, columnMappings);
+    }
+    
+    public PojoMetadata(Class clazz, boolean caseSensitive, boolean autoDeriveColumnNames, Map<String,String> columnMappings){
         
         this.caseSensitive = caseSensitive;
+        this.autoDeriveColumnNames = autoDeriveColumnNames;
         this.clazz = clazz;
         this.columnMappings = columnMappings == null ? new HashMap<String, String>() : columnMappings;
 
@@ -64,6 +72,11 @@ public class PojoMetadata {
         
         String name = this.caseSensitive ? propertyName : propertyName.toLowerCase();
 
+        if(autoDeriveColumnNames) {
+        	name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name);
+        	if(!this.caseSensitive) name = name.toLowerCase();
+        }
+        
         if (this.columnMappings.containsKey(name)){
             name = this.columnMappings.get(name);
         }


### PR DESCRIPTION
This project could support enabling auto translation or auto mapping of java field names to database columns based on the following convention:

`Query` now supports ability to enable auto column mapping.

```
private String fieldOne;
private String fiendNumber2;
```

maps to database column: field_one and field_number_2 respectively if enabled

This would cut down on lots of unnecessary calls to `addColumnMapping` just to get what could be considered default mappings supported my most (all?) other ORM libraries.

This feature can be enabled by calling `query.setAutoDeriveColumnNames(true)` and that setting lasts for the duration of the query.
