### PR TITLE
Auto Map Fieldnames

### DIFF
--- a/src/main/java/org/sql2o/Query.java
+++ b/src/main/java/org/sql2o/Query.java
@@ -52,6 +52,7 @@ public class Query {
     private NamedParameterStatement statement;
 
     private boolean caseSensitive;
+    private boolean autoDeriveColumnNames;
     
     private final String name;
     private boolean returnGeneratedKeys;
@@ -248,6 +249,15 @@ public class Query {
         this.caseSensitive = caseSensitive;
         return this;
     }
+
+    public boolean isAutoDeriveColumnNames() {
+    	return autoDeriveColumnNames;
+    }
+    
+    public Query setAutoDeriveColumnNames(boolean autoDeriveColumnNames) {
+    	this.autoDeriveColumnNames = autoDeriveColumnNames;
+    	return this;
+    }
     
     public Connection getConnection(){
         return this.connection;
@@ -259,7 +269,7 @@ public class Query {
 
     public <T> List<T> executeAndFetch(Class returnType){
         List list = new ArrayList();
-        PojoMetadata metadata = new PojoMetadata(returnType, this.isCaseSensitive(), this.getColumnMappings());
+        PojoMetadata metadata = new PojoMetadata(returnType, this.isCaseSensitive(), this.isAutoDeriveColumnNames(), this.getColumnMappings());
         try{
             //java.util.Date st = new java.util.Date();
             long start = System.currentTimeMillis();

--- a/src/main/java/org/sql2o/reflection/PojoMetadata.java
+++ b/src/main/java/org/sql2o/reflection/PojoMetadata.java
@@ -1,6 +1,7 @@
 package org.sql2o.reflection;
 
 import org.sql2o.Sql2oException;
+import org.sql2o.tools.UnderscoreToCamelCase;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -15,6 +16,7 @@ public class PojoMetadata {
     private Map<String, Setter> propertySetters;
     private Map<String, Field> fields;
     private boolean caseSensitive;
+    private boolean autoDeriveColumnNames;
     private Class clazz;
     
     private Map<String,String> columnMappings;
@@ -23,9 +25,13 @@ public class PojoMetadata {
         return columnMappings;
     }
 
-    public PojoMetadata(Class clazz, boolean caseSensitive, Map<String,String> columnMappings){
-        
+    public PojoMetadata(Class clazz, boolean caseSensitive, Map<String,String> columnMappings) {
+        this(clazz, caseSensitive, false, columnMappings);
+    }
+    
+    public PojoMetadata(Class clazz, boolean caseSensitive, boolean autoDeriveColumnNames, Map<String,String> columnMappings) {
         this.caseSensitive = caseSensitive;
+        this.autoDeriveColumnNames = autoDeriveColumnNames;
         this.clazz = clazz;
         this.columnMappings = columnMappings == null ? new HashMap<String, String>() : columnMappings;
 
@@ -66,6 +72,11 @@ public class PojoMetadata {
 
         if (this.columnMappings.containsKey(name)){
             name = this.columnMappings.get(name);
+        }
+        
+        if(autoDeriveColumnNames) {
+        	name = UnderscoreToCamelCase.convert(name);
+        	if(!this.caseSensitive) name = name.toLowerCase();
         }
         
         if (propertySetters.containsKey(name)){

--- a/src/main/java/org/sql2o/tools/UnderscoreToCamelCase.java
+++ b/src/main/java/org/sql2o/tools/UnderscoreToCamelCase.java
@@ -1,0 +1,28 @@
+package org.sql2o.tools;
+
+/**
+ * Takes a string formatted like: 'my_string_variable' and returns it as: 'myStringVariable'
+ * 
+ * @author ryancarlson
+ */
+public class UnderscoreToCamelCase {
+	public static String convert(String underscore) {
+		if(underscore == null || underscore.trim().length() == 0) return underscore;
+		String[] stringTokens = underscore.split("_");
+		
+		StringBuilder camelCase = new StringBuilder();
+		
+		for(int i = 0; i < stringTokens.length; i++) {
+			if(i == 0) {
+				/*the first word, which precedes the first underscore will be all lowercase*/
+				camelCase.append(stringTokens[i].toLowerCase());
+			}
+			else {
+				/*all subsequent words will have the first character in upper case, and the rest of the word in lower case*/
+				camelCase.append(Character.toUpperCase(stringTokens[i].charAt(0))).append(stringTokens[i].substring(1,stringTokens[i].length()).toLowerCase());
+			}
+		}
+		
+		return camelCase.toString();
+	}
+}

--- a/src/test/java/org/sql2o/tools/UnderscoreToCamelCaseTests.java
+++ b/src/test/java/org/sql2o/tools/UnderscoreToCamelCaseTests.java
@@ -1,0 +1,27 @@
+package org.sql2o.tools;
+
+import junit.framework.TestCase;
+
+public class UnderscoreToCamelCaseTests extends TestCase {
+
+	public void testBasicConversions() {
+		assertEquals("myStringVariable", UnderscoreToCamelCase.convert("my_string_variable"));
+		assertEquals("string", UnderscoreToCamelCase.convert("string"));
+		assertEquals("myReallyLongStringVariableName", UnderscoreToCamelCase.convert("my_really_long_string_variable_name"));
+		assertEquals("myString2WithNumbers4", UnderscoreToCamelCase.convert("my_string2_with_numbers_4"));
+		assertEquals("myStringWithMixedCase", UnderscoreToCamelCase.convert("my_string_with_MixED_CaSe"));
+	}
+	
+	public void testNullString() {
+		assertNull(UnderscoreToCamelCase.convert(null));
+	}
+	
+	public void testEmptyStrings() {
+		assertEquals("", UnderscoreToCamelCase.convert(""));
+		assertEquals(" ", UnderscoreToCamelCase.convert(" "));
+	}
+	public void testWhitespace() {
+		assertEquals("\t", UnderscoreToCamelCase.convert("\t"));
+		assertEquals("\n\n", UnderscoreToCamelCase.convert("\n\n"));
+	}
+}


### PR DESCRIPTION
This project could support enabling auto translation or auto mapping of java field names to database columns based on the following convention:

`Query` now supports ability to enable auto column mapping.

```
private String fieldOne;
private String fiendNumber2;
maps to database column: field_one and field_number_2 respectively if enabled
```

This would cut down on lots of unnecessary calls to addColumnMapping just to get what could be considered default mappings supported my most (all?) other ORM libraries.

This feature can be enabled by calling query.setAutoDeriveColumnNames(true) and that setting lasts for the duration of the query.
