### PR TITLE
Joda DateTime should be converted to java.sql.Timestamp, not java.sql.Date

### DIFF
--- a/src/main/java/org/sql2o/Query.java
+++ b/src/main/java/org/sql2o/Query.java
@@ -193,8 +193,8 @@ public class Query {
     }
 
     public Query addParameter(String name, DateTime value){
-        java.util.Date dtVal = value == null ? null : value.toDate();
-        return addParameter(name, dtVal);
+        Timestamp timestamp = value == null ? null : new Timestamp(value.toDate().getTime());
+        return addParameter(name, timestamp);
     }
 
     public Query addParameter(String name, Enum value) {

--- a/src/main/java/org/sql2o/converters/JodaTimeConverter.java
+++ b/src/main/java/org/sql2o/converters/JodaTimeConverter.java
@@ -1,6 +1,7 @@
 package org.sql2o.converters;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 /**
  * Used by sql2o to convert a value from the database into a {@link DateTime} instance.
@@ -12,7 +13,7 @@ public class JodaTimeConverter implements Converter<DateTime> {
         }
         
         try{
-            return new DateTime(val);
+            return new DateTime(val,DateTimeZone.UTC);
         }
         catch(Throwable t){
             throw new ConverterException("Error while converting type " + val.getClass().toString() + " to jodatime", t);


### PR DESCRIPTION
The Joda DateTime parameter should be converted to a Timestamp so the time factor is not lost.  Converting to a java.sql.Date loses any time associated with the DateTime.

If it's desired to just save a Date, then a joda LocalTime should be accepted as a separate parameter and it can be converted to a java.sql.Date.

Additional change, open for debate:  
- Should return a DateTime in UTC.  Otherwise timezone of the JVM is assumed, which could be problematic.
