### PR TITLE
Add Query.executeAndFetchLazy for lazy reading

### DIFF
--- a/src/main/java/org/sql2o/ResultSetIterable.java
+++ b/src/main/java/org/sql2o/ResultSetIterable.java
@@ -1,0 +1,12 @@
+package org.sql2o;
+
+/**
+ * Iterable {@link java.sql.ResultSet}. Needs to be closeable, because allowing manual
+ * iteration means it's impossible to know when to close the ResultSet and Connection.
+ *
+ * @author aldenquimby@gmail.com
+ */
+public interface ResultSetIterable<T> extends Iterable<T>, AutoCloseable {
+    // override close to not throw
+    void close();
+}

--- a/src/main/java/org/sql2o/ResultSetIterator.java
+++ b/src/main/java/org/sql2o/ResultSetIterator.java
@@ -1,0 +1,108 @@
+package org.sql2o;
+
+import org.sql2o.reflection.Pojo;
+import org.sql2o.reflection.PojoMetadata;
+import org.sql2o.tools.ResultSetUtils;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator for a {@link java.sql.ResultSet}. Tricky part here is getting {@link #hasNext()}
+ * to work properly, meaning it can be called multiple times without calling {@link #next()}.
+ *
+ * @author aldenquimby@gmail.com
+ */
+public class ResultSetIterator<T> implements Iterator<T> {
+    // fields needed to read result set
+    private ResultSet rs;
+    private ResultSetMetaData meta;
+    private PojoMetadata metadata;
+    private boolean isCaseSensitive;
+    private QuirksMode quirksMode;
+
+    public ResultSetIterator(ResultSet rs, PojoMetadata metadata, boolean isCaseSensitive, QuirksMode quirksMode) {
+        this.rs = rs;
+        this.metadata = metadata;
+        this.isCaseSensitive = isCaseSensitive;
+        this.quirksMode = quirksMode;
+        try {
+            meta = rs.getMetaData();
+        }
+        catch(SQLException ex) {
+            throw new Sql2oException("Database error: " + ex.getMessage(), ex);
+        }
+    }
+
+    // fields needed to properly implement
+    private T next; // keep track of next item in case hasNext() is called multiple times
+    private boolean resultSetFinished; // used to note when result set exhausted
+
+    public boolean hasNext() {
+        // check if we already fetched next item
+        if (next != null) {
+            return true;
+        }
+
+        // check if result set already finished
+        if (resultSetFinished) {
+            return false;
+        }
+
+        // now fetch next item
+        next = readNext();
+
+        // check if we got something
+        if (next != null) {
+            return true;
+        }
+
+        // no more items
+        resultSetFinished = true;
+
+        return false;
+    }
+
+    public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        T result = next;
+
+        next = null;
+
+        return result;
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    private T readNext() {
+        try {
+            if (rs.next()) {
+                Pojo pojo = new Pojo(metadata, isCaseSensitive);
+
+                for(int colIdx = 1; colIdx <= meta.getColumnCount(); colIdx++) {
+                    String colName;
+                    if (quirksMode == QuirksMode.DB2){
+                        colName = meta.getColumnName(colIdx);
+                    } else {
+                        colName = meta.getColumnLabel(colIdx);
+                    }
+                    pojo.setProperty(colName, ResultSetUtils.getRSVal(rs, colIdx));
+                }
+
+                return (T)pojo.getObject();
+            }
+        }
+        catch (SQLException ex) {
+            throw new Sql2oException("Database error: " + ex.getMessage(), ex);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/sql2o/tools/ResultSetUtils.java
+++ b/src/main/java/org/sql2o/tools/ResultSetUtils.java
@@ -1,0 +1,20 @@
+package org.sql2o.tools;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Utilities for {@link java.sql.ResultSet}.
+ */
+public class ResultSetUtils {
+    public static Object getRSVal(ResultSet rs, int idx) throws SQLException {
+        Object o = rs.getObject(idx);
+        // oracle timestamps are not always convertible to a java Date. If ResultSet.getTimestamp is used instead of
+        // ResultSet.getObject, a normal java.sql.Timestamp instance is returnd.
+        if (o != null && o.getClass().getCanonicalName().startsWith("oracle.sql.TIMESTAMP")){
+            o = rs.getTimestamp(idx);
+        }
+
+        return o;
+    }
+}

--- a/src/test/java/org/sql2o/Sql2oTest.java
+++ b/src/test/java/org/sql2o/Sql2oTest.java
@@ -888,7 +888,7 @@ public class Sql2oTest {
     public void testExecuteAndFetchLazy(){
         createAndFillUserTable();
 
-        Iterable<User> allUsers = sql2o.createQuery("select * from User").executeAndFetchLazy(User.class);
+        ResultSetIterable<User> allUsers = sql2o.createQuery("select * from User").executeAndFetchLazy(User.class);
 
         // read in batches, because maybe we are bulk exporting and can't fit them all into a list
         int totalSize = 0;
@@ -903,10 +903,36 @@ public class Sql2oTest {
             batch.add(u);
         }
 
+        allUsers.close();
+
         assertTrue(totalSize == insertIntoUsers);
         deleteUserTable();
     }
 
+    @Test
+    public void testResultSetIterator_multipleHasNextWorks() {
+        createAndFillUserTable();
+
+        ResultSetIterable<User> allUsers = sql2o.createQuery("select * from User").executeAndFetchLazy(User.class);
+
+        Iterator<User> usersIterator = allUsers.iterator();
+
+        // call hasNext a few times, should have no effect
+        usersIterator.hasNext();
+        usersIterator.hasNext();
+        usersIterator.hasNext();
+
+        int totalSize = 0;
+        while (usersIterator.hasNext()) {
+            totalSize++;
+            usersIterator.next();
+        }
+
+        allUsers.close();
+
+        assertTrue(totalSize == insertIntoUsers);
+        deleteUserTable();
+    }
 
     /************** Helper stuff ******************/
 


### PR DESCRIPTION
Also improves performance of `Query.executeAndFetchFirst`, which no longer reads all rows from a `ResultSet`.

See https://github.com/aaberg/sql2o/issues/40 for explanation and comments.
