### PR TITLE
Added executeWithoutResult method to Query

### DIFF
--- a/src/main/java/org/sql2o/Query.java
+++ b/src/main/java/org/sql2o/Query.java
@@ -370,6 +370,20 @@ public class Query {
         }
     }
     
+    public void executeWithoutResult(){
+        long start = System.currentTimeMillis();
+        try {
+            this.statement.executeQuery();
+        }
+        catch (SQLException e) {
+            this.connection.onException();
+            throw new Sql2oException("Database error occurred while running executeWithoutReturn: " + e.getMessage(), e);
+        }
+        finally{
+            closeConnectionIfNecessary();
+        }
+    }
+
     public Table executeAndFetchTable(){
         ResultSet rs;
         long start = System.currentTimeMillis();


### PR DESCRIPTION
Added executeWithoutResult method to query to be able to run statements without any resultset. I cannot run a MERGE statement without it, because the Oracle JDBC driver droped an Exception on rs.next().
