### PR TITLE
add ability to return keys from a batch

### DIFF
--- a/src/main/java/org/sql2o/Connection.java
+++ b/src/main/java/org/sql2o/Connection.java
@@ -201,6 +201,31 @@ public class Connection implements AutoCloseable {
         return null;
     }
 
+    public <V> List<V> getKeys(Class<V> returnType) {
+        if (!isCanGetKeys()) {
+            throw new Sql2oException("Keys where not fetched from database. Please call executeUpdate() to fetch keys");
+        }
+
+        if (this.keys != null) {
+            try {
+                Converter converter = Convert.getConverter(returnType);
+
+                List<V> convertedKeys = new ArrayList<V>(this.keys.size());
+
+                for (Object key : this.keys) {
+                        convertedKeys.add((V)converter.convert(key));
+                }
+
+                return convertedKeys;
+            }
+            catch (ConverterException e) {
+                throw new Sql2oException("Exception occurred while converting value from database to type " + returnType.toString(), e);
+            }
+        }
+
+        return null;
+    }
+
     public boolean isCanGetKeys() {
         return canGetKeys;
     }

--- a/src/main/java/org/sql2o/Query.java
+++ b/src/main/java/org/sql2o/Query.java
@@ -530,7 +530,9 @@ public class Query {
     public Connection executeBatch() throws Sql2oException {
         long start = System.currentTimeMillis();
         try {
-            connection.setBatchResult( statement.executeBatch() );
+            connection.setBatchResult(statement.executeBatch());
+            connection.setKeys(this.returnGeneratedKeys ? statement.getStatement().getGeneratedKeys() : null);
+            connection.setCanGetKeys(this.returnGeneratedKeys);
         }
         catch (Throwable e) {
             this.connection.onException();


### PR DESCRIPTION
- sets Connection in `executeBatch` if `returnGeneratedKeys`
- adds generic `Connection.getKeys()`
- adds executeBatch + getKeys test for h2 and hypersql
