### PR TITLE
ref #31, added stored procedure and output parameter support

### DIFF
--- a/core/src/main/java/org/sql2o/AfterExecuteObservable.java
+++ b/core/src/main/java/org/sql2o/AfterExecuteObservable.java
@@ -1,0 +1,12 @@
+package org.sql2o;
+
+/**
+ * Created by lars on 17.04.14.
+ */
+public interface AfterExecuteObservable {
+
+    void attachAfterExecuteObserver(AfterExecuteObserver observer);
+
+    void notifyAfterexecute();
+
+}

--- a/core/src/main/java/org/sql2o/AfterExecuteObserver.java
+++ b/core/src/main/java/org/sql2o/AfterExecuteObserver.java
@@ -1,0 +1,8 @@
+package org.sql2o;
+
+/**
+ * Created by lars on 17.04.14.
+ */
+public interface AfterExecuteObserver {
+    void update(Query query);
+}

--- a/core/src/main/java/org/sql2o/Connection.java
+++ b/core/src/main/java/org/sql2o/Connection.java
@@ -77,7 +77,7 @@ public class Connection implements AutoCloseable {
             throw new RuntimeException(e);
         }
 
-        return new Query(this, queryText, name, returnGeneratedKeys);
+        return new SqlQuery(this, queryText, name, returnGeneratedKeys);
     }
     
     public Query createQuery(String queryText){
@@ -86,6 +86,14 @@ public class Connection implements AutoCloseable {
 
     public Query createQuery(String queryText, boolean returnGeneratedKeys) {
         return createQuery(queryText, null, returnGeneratedKeys);
+    }
+
+    public Query createProcedureCall(String commandText) {
+        return createProcedureCall(commandText, null);
+    }
+
+    public Query createProcedureCall(String commandText, String name) {
+        return new ProcedureCall(this, commandText, name);
     }
 
     public Sql2o rollback(){

--- a/core/src/main/java/org/sql2o/OutParameter.java
+++ b/core/src/main/java/org/sql2o/OutParameter.java
@@ -1,0 +1,96 @@
+package org.sql2o;
+
+import org.sql2o.tools.OutParameterGetter;
+
+import java.sql.CallableStatement;
+import java.sql.SQLException;
+
+/**
+ * Created by lars on 16.04.14.
+ */
+public class OutParameter<T> {
+
+    private final String name;
+    private T value;
+
+    private OutParameterGetter<T> outParameterGetter;
+    private Class paramGetterClass;
+    private final RegisterParam registerParam;
+
+    public OutParameter(String name, final int type, OutParameterGetter outParameterGetter) {
+        registerParam = new RegisterParam() {
+            public void registerOutParam(int paramIdx, CallableStatement statement) throws SQLException {
+                statement.registerOutParameter(paramIdx, type);
+            }
+        };
+        this.name = name;
+        this.outParameterGetter = outParameterGetter;
+    }
+
+    public OutParameter(String name, final int type, final int scale, OutParameterGetter outParameterGetter) {
+        registerParam = new RegisterParam() {
+            public void registerOutParam(int paramIdx, CallableStatement statement) throws SQLException {
+                statement.registerOutParameter(paramIdx, type, scale);
+            }
+        };
+        this.name = name;
+        this.outParameterGetter = outParameterGetter;
+    }
+
+    public OutParameter(String name, final int type, final String typeName, OutParameterGetter outParameterGetter) {
+        registerParam = new RegisterParam() {
+            public void registerOutParam(int paramIdx, CallableStatement statement) throws SQLException {
+                statement.registerOutParameter(paramIdx, type, typeName);
+            }
+        };
+        this.name = name;
+        this.outParameterGetter = outParameterGetter;
+    }
+
+    public OutParameter(String name, int sqlType, Class outputType) {
+        this(name, sqlType, (OutParameterGetter)null);
+        paramGetterClass = outputType;
+    }
+
+    public OutParameter(String name, int sqlType, int scale, Class outputType){
+        this(name, sqlType, scale, (OutParameterGetter)null);
+        paramGetterClass = outputType;
+    }
+
+    public OutParameter(String name, int sqlType, String typeName, Class outputType) {
+        this(name, sqlType, typeName, (OutParameterGetter)null);
+        paramGetterClass = outputType;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public OutParameterGetter<T> getOutParameterGetter() {
+        return outParameterGetter;
+    }
+
+    public void setOutParameterGetter(OutParameterGetter<T> outParameterGetter) {
+        this.outParameterGetter = outParameterGetter;
+    }
+
+    public Class getParamGetterClass() {
+        return paramGetterClass;
+    }
+
+    public void registerParam(CallableStatement callableStatement, int paramIdx) throws SQLException {
+        this.registerParam.registerOutParam(paramIdx, callableStatement);
+    }
+
+    private interface RegisterParam {
+        void registerOutParam(int paramIdx, CallableStatement statement) throws SQLException;
+    }
+}

--- a/core/src/main/java/org/sql2o/ProcedureCall.java
+++ b/core/src/main/java/org/sql2o/ProcedureCall.java
@@ -1,0 +1,48 @@
+package org.sql2o;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * Created by lars on 15.04.14.
+ */
+public class ProcedureCall extends Query {
+
+    private final CallableStatement statement;
+
+    public ProcedureCall(Connection connection, String queryText, String name) {
+        super(connection, queryText, name, false);
+
+        try {
+            statement = connection.getJdbcConnection().prepareCall(getParsedQuery());
+        } catch (SQLException e) {
+            throw new Sql2oException("Error creating new instance of CallableStatement", e);
+        }
+
+    }
+
+    @Override
+    protected PreparedStatement getStatement() {
+        return statement;
+    }
+
+    public CallableStatement getCallableStatement() {
+        return statement;
+    }
+
+
+    @Override
+    public <V> Query addParameter(OutParameter<V> parameter) {
+        try {
+            this.getQuirks().registerOutParameter(this, parameter);
+        } catch (SQLException e) {
+            throw new Sql2oException("Error registering output parameter", e);
+        }
+        return this;
+    }
+
+
+
+
+}

--- a/core/src/main/java/org/sql2o/QuirksMode.java
+++ b/core/src/main/java/org/sql2o/QuirksMode.java
@@ -5,10 +5,10 @@ import org.sql2o.quirks.Db2Quirks;
 import org.sql2o.quirks.NoQuirks;
 import org.sql2o.quirks.PostgresQuirks;
 import org.sql2o.quirks.Quirks;
+import org.sql2o.tools.OutParameterGetter;
 
 import java.io.InputStream;
 import java.sql.*;
-import java.util.Map;
 
 /**
  * Use {@link org.sql2o.quirks.Quirks}.
@@ -26,6 +26,11 @@ public enum QuirksMode implements Quirks {
     public <E> Converter<E> converterOf(Class<E> ofClass) {
         return quirks.converterOf(ofClass);
     }
+
+    public <E> OutParameterGetter<E> outParamGetterOf(Class<E> ofClass) {
+        return quirks.outParamGetterOf(ofClass);
+    }
+
 
     public String getColumnName(ResultSetMetaData meta, int colIdx) throws SQLException {
         return quirks.getColumnName(meta, colIdx);
@@ -69,6 +74,10 @@ public enum QuirksMode implements Quirks {
 
     public void setParameter(PreparedStatement statement, int paramIdx, Time value) throws SQLException {
         quirks.setParameter(statement, paramIdx, value);
+    }
+
+    public void registerOutParameter(ProcedureCall procedureCall, OutParameter parameter) throws SQLException {
+        quirks.registerOutParameter(procedureCall, parameter);
     }
 
     public Object getRSVal(ResultSet rs, int idx) throws SQLException {

--- a/core/src/main/java/org/sql2o/Sql2o.java
+++ b/core/src/main/java/org/sql2o/Sql2o.java
@@ -1,7 +1,5 @@
 package org.sql2o;
 
-import org.sql2o.converters.Convert;
-import org.sql2o.converters.Converter;
 import org.sql2o.quirks.NoQuirks;
 import org.sql2o.quirks.Quirks;
 import org.sql2o.tools.DefaultSqlParameterParsingStrategy;
@@ -227,6 +225,14 @@ public class Sql2o {
      */
     public Query createQuery(String query){
         return createQuery(query, null);
+    }
+
+    public Query createProcedureCall(String commandText) {
+        return new Connection(this, true).createProcedureCall(commandText);
+    }
+
+    public Query createProcedureCall(String commandText, String name) {
+        return new Connection(this, true).createProcedureCall(commandText, name);
     }
 
     /**

--- a/core/src/main/java/org/sql2o/SqlQuery.java
+++ b/core/src/main/java/org/sql2o/SqlQuery.java
@@ -1,0 +1,37 @@
+package org.sql2o;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Created by lars on 15.04.14.
+ */
+public class SqlQuery extends Query {
+
+    private final PreparedStatement statement;
+
+    public SqlQuery(Connection connection, String queryText, String name, boolean returnGeneratedKeys) {
+        super(connection, queryText, name, returnGeneratedKeys);
+
+        try {
+            if (returnGeneratedKeys) {
+                statement = getConnection().getJdbcConnection().prepareStatement(getParsedQuery(), Statement.RETURN_GENERATED_KEYS);
+            } else {
+                statement = getConnection().getJdbcConnection().prepareStatement(getParsedQuery());
+            }
+        } catch(SQLException ex) {
+            throw new RuntimeException(String.format("Error preparing statement - %s", ex.getMessage()), ex);
+        }
+    }
+
+    @Override
+    protected PreparedStatement getStatement() {
+        return statement;
+    }
+
+    @Override
+    public <V> Query addParameter(OutParameter<V> parameter) {
+        throw new Sql2oException("Output parameters are not supported when using createQuery method. Use createProcedureCall method instead");
+    }
+}

--- a/core/src/main/java/org/sql2o/quirks/Quirks.java
+++ b/core/src/main/java/org/sql2o/quirks/Quirks.java
@@ -1,13 +1,12 @@
 package org.sql2o.quirks;
 
+import org.sql2o.OutParameter;
+import org.sql2o.ProcedureCall;
 import org.sql2o.converters.Converter;
+import org.sql2o.tools.OutParameterGetter;
 
 import java.io.InputStream;
 import java.sql.*;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.util.Map;
 
 /**
  * Interface for JDBC driver specific quirks.
@@ -24,6 +23,8 @@ public interface Quirks {
      */
 
     <E> Converter<E> converterOf(Class<E> ofClass);
+
+    <E> OutParameterGetter<E> outParamGetterOf(Class<E> ofClass);
 
 
     /**
@@ -46,5 +47,9 @@ public interface Quirks {
     void setParameter(PreparedStatement statement, int paramIdx, Timestamp value) throws SQLException;
     void setParameter(PreparedStatement statement, int paramIdx, Time value) throws SQLException;
 
+    <V> void registerOutParameter(ProcedureCall procedureCall, OutParameter<V> parameter) throws SQLException;
+
     Object getRSVal(ResultSet rs, int idx) throws SQLException;
+
+
 }

--- a/core/src/main/java/org/sql2o/tools/DefaultOutParameterGetters.java
+++ b/core/src/main/java/org/sql2o/tools/DefaultOutParameterGetters.java
@@ -1,0 +1,128 @@
+package org.sql2o.tools;
+
+import java.math.BigDecimal;
+import java.sql.CallableStatement;
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by lars on 16.04.14.
+ */
+public class DefaultOutParameterGetters {
+
+    public Map<Class, OutParameterGetter> map(){
+        Map<Class, OutParameterGetter> map = new HashMap<Class, OutParameterGetter>();
+
+        map.put(boolean.class, new BooleanOutParameterGetter());
+        map.put(Boolean.class, new BooleanOutParameterGetter());
+
+        map.put(byte.class, new ByteOutParameterGetter());
+        map.put(Byte.class, new ByteOutParameterGetter());
+
+        map.put(short.class, new ShortOutParameterGetter());
+        map.put(Short.class, new ShortOutParameterGetter());
+
+        map.put(int.class, new IntegerOutParameterGetter());
+        map.put(Integer.class, new IntegerOutParameterGetter());
+
+        map.put(long.class, new LongOutParameterGetter());
+        map.put(Long.class, new LongOutParameterGetter());
+
+        map.put(float.class, new FloatOutParameterGetter());
+        map.put(Float.class, new FloatOutParameterGetter());
+
+        map.put(double.class, new DoubleOutParameterGetter());
+        map.put(Double.class, new DoubleOutParameterGetter());
+
+        map.put(BigDecimal.class, new BigDecimalOutParameterGetter());
+
+        map.put(String.class, new StringOutParameterGetter());
+
+        map.put(Date.class, new DateOutParameterGetter());
+
+        map.put(byte[].class, new ByteArrayOutParameterGetter());
+
+        return map;
+    }
+
+    private class BooleanOutParameterGetter implements OutParameterGetter<Boolean> {
+
+        public Boolean handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getBoolean(paramIdx);
+        }
+    }
+
+    private class ByteOutParameterGetter implements OutParameterGetter<Byte> {
+
+        public Byte handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getByte(paramIdx);
+        }
+    }
+    
+    private class ShortOutParameterGetter implements OutParameterGetter<Short> {
+
+        public Short handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getShort(paramIdx);
+        }
+    }
+
+    private class IntegerOutParameterGetter implements OutParameterGetter<Integer> {
+
+        public Integer handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getInt(paramIdx);
+        }
+    }
+
+    private class LongOutParameterGetter implements  OutParameterGetter<Long> {
+
+        public Long handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getLong(paramIdx);
+        }
+    }
+
+    private class FloatOutParameterGetter implements OutParameterGetter<Float> {
+
+        public Float handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getFloat(paramIdx);
+        }
+    }
+
+    private class DoubleOutParameterGetter implements OutParameterGetter<Double> {
+
+        public Double handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getDouble(paramIdx);
+        }
+    }
+
+    private class BigDecimalOutParameterGetter implements OutParameterGetter<BigDecimal> {
+
+        public BigDecimal handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getBigDecimal(paramIdx);
+        }
+    }
+
+    private class StringOutParameterGetter implements OutParameterGetter<String> {
+
+        public String handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getString(paramIdx);
+        }
+    }
+
+    private class DateOutParameterGetter implements OutParameterGetter<Date> {
+
+        public Date handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getDate(paramIdx);
+        }
+    }
+
+    private class ByteArrayOutParameterGetter implements OutParameterGetter<byte[]> {
+
+        public byte[] handle(CallableStatement statement, int paramIdx) throws SQLException {
+            return statement.getBytes(paramIdx);
+        }
+    }
+
+
+}

--- a/core/src/main/java/org/sql2o/tools/OutParameterGetter.java
+++ b/core/src/main/java/org/sql2o/tools/OutParameterGetter.java
@@ -1,0 +1,12 @@
+package org.sql2o.tools;
+
+import java.sql.CallableStatement;
+import java.sql.SQLException;
+
+/**
+ * Created by lars on 15.04.14.
+ */
+public interface OutParameterGetter<V> {
+
+    V handle(CallableStatement statement, int paramIdx) throws SQLException;
+}

--- a/core/src/test/java/org/sql2o/issues/ProcedureJdbcTest.java
+++ b/core/src/test/java/org/sql2o/issues/ProcedureJdbcTest.java
@@ -1,0 +1,113 @@
+package org.sql2o.issues;
+
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.sql2o.*;
+import org.sql2o.quirks.PostgresQuirks;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Created by lars on 14.04.14.
+ */
+public class ProcedureJdbcTest extends TestCase {
+
+    private final Sql2o sql2o;
+    public ProcedureJdbcTest() {
+        sql2o = new Sql2o("jdbc:postgresql:testdb", "test", "testtest", new PostgresQuirks());
+    }
+
+    @Before
+    public void setUp() {
+        String createProc =
+                "CREATE OR REPLACE FUNCTION testfunc(IN arg1 integer, OUT arg2 integer, OUT arg3 integer)\n" +
+                "  RETURNS record AS\n" +
+                "'select $1 + 1, $1 + 2'\n" +
+                "  LANGUAGE sql VOLATILE\n" +
+                "  COST 100;";
+        sql2o.createQuery(createProc).executeUpdate();
+    }
+
+    @Test
+    public void testJdbcProcedureCall() throws SQLException {
+        final Integer inputArg = 20;
+        Connection connection = sql2o.getDataSource().getConnection();
+        CallableStatement callableStatement = null;
+
+        Integer arg2;
+        Integer arg3;
+
+        try {
+            callableStatement = connection.prepareCall("{call testfunc (?,?,?)}");
+
+            callableStatement.setInt(1, inputArg);
+            callableStatement.registerOutParameter(2, Types.INTEGER);
+            callableStatement.registerOutParameter(3, Types.INTEGER);
+
+            callableStatement.execute();
+            arg2 = callableStatement.getInt(2);
+            arg3 = callableStatement.getInt(3);
+        } finally {
+            if (!callableStatement.isClosed()){
+                callableStatement.close();
+            }
+        }
+        assertThat(arg2, is(equalTo(inputArg+1)));
+        assertThat(arg3, is(equalTo(inputArg+2)));
+    }
+
+    @Test
+    public void testSql2oProcedureCall() {
+        final Integer inputArg = 20;
+        Integer arg2, arg3;
+
+        org.sql2o.Connection con = sql2o.open();
+
+        OutParameter<Integer> p2 = new OutParameter<Integer>("outParam2", Types.INTEGER, Integer.class);
+        OutParameter<Integer> p3 = new OutParameter<Integer>("outParam3", Types.INTEGER, Integer.class);
+
+        con.createProcedureCall("{call testfunc (:inParam1,:outParam2,:outParam3)}")
+                .addParameter("inParam1", inputArg)
+                .addParameter(p2)
+                .addParameter(p3)
+                .executeUpdate();
+
+        arg2 = p2.getValue();
+        arg3 = p3.getValue();
+        con.close();
+
+        assertThat(arg2, is(equalTo(inputArg + 1)));
+        assertThat(arg3, is(equalTo(inputArg+2)));
+
+    }
+
+    @Test
+    public void testSql2oDirectProcedureCall() {
+        final Integer inputArg = 20;
+        Integer arg2, arg3;
+
+        OutParameter<Integer> p2 = new OutParameter<Integer>("outParam2", Types.INTEGER, Integer.class);
+        OutParameter<Integer> p3 = new OutParameter<Integer>("outParam3", Types.INTEGER, Integer.class);
+
+        sql2o.createProcedureCall("{call testfunc (:inParam1,:outParam2,:outParam3)}")
+                .addParameter("inParam1", inputArg)
+                .addParameter(p2)
+                .addParameter(p3)
+                .executeUpdate();
+
+        arg2 = p2.getValue();
+        arg3 = p3.getValue();
+
+        assertThat(arg2, is(equalTo(inputArg + 1)));
+        assertThat(arg3, is(equalTo(inputArg+2)));
+
+    }
+}


### PR DESCRIPTION
Given the following PostgreSQL procedure:

```
CREATE OR REPLACE FUNCTION testfunc(IN arg1 integer, OUT arg2 integer, OUT arg3 integer)
RETURNS record AS
    'select $1 + 1, $1 + 2'
LANGUAGE sql VOLATILE
COST 100;
```

Sql2o can call it like this:

```
final Integer inputArg = 20;

OutParameter<Integer> p2 = new OutParameter<Integer>("outParam2", Types.INTEGER, Integer.class);
OutParameter<Integer> p3 = new OutParameter<Integer>("outParam3", Types.INTEGER, Integer.class);

sql2o.createProcedureCall("{call testfunc (:inParam1,:outParam2,:outParam3)}")
        .addParameter("inParam1", inputArg)
        .addParameter(p2)
        .addParameter(p3)
        .executeUpdate();

int outParam2 = p2.getValue();
int outParam3 = p3.getValue();
```

Any comments?
