### PR TITLE
Let jOOQ keep open PreparedStatements

### DIFF
--- a/core/src/test/java/org/sql2o/performance/PojoPerformanceTest.java
+++ b/core/src/test/java/org/sql2o/performance/PojoPerformanceTest.java
@@ -268,7 +268,8 @@ public class PojoPerformanceTest
 
             q = create.select()
                       .from("post")
-                      .where("id = ?", -1); // param needs an initial value, else future calls the bind() will fail.
+                      .where("id = ?", -1) // param needs an initial value, else future calls the bind() will fail.
+                      .keepStatement(true);
         }
 
         @Override


### PR DESCRIPTION
We're going to be implementing a series of performance improvements for the issue you've helped discover in jOOQ: https://github.com/jOOQ/jOOQ/issues/3225

To be fair, the jOOQ benchmark could profit from keeping open `PreparedStatement` references between consecutive query executions. It won't make too much of a difference given the bottleneck in https://github.com/jOOQ/jOOQ/issues/3225, but at least it is more comparable to the plain JDBC solution.

We'll keep you posted, and thanks again for helping us discover this issue
