### PR TITLE
executeScalarList() returns partial list when there are nulls

### DIFF
--- a/core/src/main/java/org/sql2o/ResultSetIteratorBase.java
+++ b/core/src/main/java/org/sql2o/ResultSetIteratorBase.java
@@ -34,7 +34,7 @@ public abstract class ResultSetIteratorBase<T> implements Iterator<T> {
     }
 
     // fields needed to properly implement
-    private T next; // keep track of next item in case hasNext() is called multiple times
+    private ResultSetValue<T> next; // keep track of next item in case hasNext() is called multiple times
     private boolean resultSetFinished; // used to note when result set exhausted
 
     public boolean hasNext() {
@@ -67,7 +67,7 @@ public abstract class ResultSetIteratorBase<T> implements Iterator<T> {
             throw new NoSuchElementException();
         }
 
-        T result = next;
+        T result = next.value;
 
         next = null;
 
@@ -78,22 +78,30 @@ public abstract class ResultSetIteratorBase<T> implements Iterator<T> {
         throw new UnsupportedOperationException();
     }
 
-    private T safeReadNext()
+    private ResultSetValue<T> safeReadNext()
     {
         try {
-            if (rs.next()) {
-                return readNext();
-            }
+            if (!rs.next())
+                return null;
+
+            return new ResultSetValue(readNext());
         }
         catch (SQLException ex) {
             throw new Sql2oException("Database error: " + ex.getMessage(), ex);
         }
-        return null;
     }
 
     protected abstract T readNext() throws SQLException;
 
     protected String getColumnName(int colIdx) throws SQLException {
         return quirks.getColumnName(meta, colIdx);
+    }
+
+    private final class ResultSetValue<T> {
+        public final T value;
+
+        public ResultSetValue(T value){
+            this.value = value;
+        }
     }
 }

--- a/core/src/test/java/org/sql2o/Sql2oTest.java
+++ b/core/src/test/java/org/sql2o/Sql2oTest.java
@@ -261,7 +261,24 @@ public class Sql2oTest {
         assertEquals((int)list.get(0), 1);
         assertEquals((int)list.get(1), 2);
         assertEquals((int)list.get(2), 3);
+    }
 
+    @Test
+    public void testExecuteScalarListWithNulls() throws SQLException {
+        List<String> list = sql2o.createQuery("select val from ( "+
+                                              "select 1 ord, null val from (values(0)) union " +
+                                              "select 2 ord, 'one' from (values(0)) union " +
+                                              "select 3 ord, null from (values(0)) union " +
+                                              "select 4 ord, 'two' from (values(0)) " +
+                                              ") order by ord")  // explicit ordering since nulls seem to mess with ordering
+                                 .executeScalarList(String.class);
+
+        assertEquals(4, list.size());
+
+        assertNull(list.get(0));
+        assertEquals(list.get(1), "one");
+        assertNull(list.get(2));
+        assertEquals(list.get(3), "two");
     }
 
     @Test


### PR DESCRIPTION
executeScalarList() will not process all rows in the result set if there are nulls.  `ResultSetIteratorBase<T>.hasNext()` assumes that null means the end of the result set, but that may not be true if one of the scalars is null.  

This change just wraps the value, so the wrapper can be checked for null.  The wrapped value can then be null without affecting result set iteration.
