### PR TITLE
-Changed the return type to Object to be more consistent with the other

### DIFF
--- a/core/src/main/java/org/sql2o/converters/AbstractDateConverter.java
+++ b/core/src/main/java/org/sql2o/converters/AbstractDateConverter.java
@@ -35,7 +35,7 @@ public abstract class AbstractDateConverter<E extends Date> implements Converter
         throw new ConverterException("Cannot convert type " + val.getClass().toString() + " to java.util.Date");
     }
 
-    public Timestamp toDatabaseParam(Date val) {
+    public Object toDatabaseParam(Date val) {
         if(val==null) return null;
         return (val instanceof Timestamp)
                 ? (Timestamp) val


### PR DESCRIPTION
This is a very small change but it serves two purposes:
1) It makes the code style more consistent with the other Converters, I have checked the call hierarchy of this method and there is no need for it to be Timestamp
2) It fixed a build error with Eclipse, that I believe it is caused by a bug in Eclipse but I think it's still an acceptable solution.