### PR TITLE
-Add travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+before_script:
+ - psql -c "CREATE USER test WITH PASSWORD 'testtest';" -U postgres
+ - psql -c "CREATE DATABASE testdb WITH OWNER test;" -U postgres
+install:
+ - mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl core,extensions,extensions/db2,extensions/postgres
+script:
+ - mvn test -Dmaven.javadoc.skip=true -B -V -pl core,extensions,extensions/postgres

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sql2o [![Build Status](https://travis-ci.org/viftodi/sql2o.svg?branch=travis-test)](https://travis-ci.org/viftodi/sql2o)
+# sql2o [![Build Status](https://travis-ci.org/viftodi/sql2o.svg)](https://travis-ci.org/viftodi/sql2o)
 
 Sql2o is a small java library, with the purpose of making database interaction easy.
 When fetching data from the database, the ResultSet will automatically be filled into you POJO objects.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sql2o [![Build Status](https://travis-ci.org/viftodi/sql2o.svg)](https://travis-ci.org/viftodi/sql2o)
+# sql2o [![Build Status](https://travis-ci.org/viftodi/sql2o.svg?branch=master)](https://travis-ci.org/viftodi/sql2o)
 
 Sql2o is a small java library, with the purpose of making database interaction easy.
 When fetching data from the database, the ResultSet will automatically be filled into you POJO objects.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sql2o
+# sql2o [![Build Status](https://travis-ci.org/viftodi/sql2o.svg?branch=travis-test)](https://travis-ci.org/viftodi/sql2o)
 
 Sql2o is a small java library, with the purpose of making database interaction easy.
 When fetching data from the database, the ResultSet will automatically be filled into you POJO objects.


### PR DESCRIPTION
Hello,
This modification adds a simple (for now) Travis CI integration.
It builds sql2o (except the oracle extension due to the non publicly available jar)
And it tests sql2o, skiping db2 and oracle due to the missing jar, and because these databases are not supported in Travis CI. (db2 doesn't even have tests for now)
I think this can be quite useful as it means that tests can be created and ran (on h2, postgres, open source databases... even mysql or neo4j if neded in the future) without having the need to configure them in a local environment.
In the future  the travis config can evolve to have maybe even email alerts or other cool stuff, or maybe publish performance results (don't know if it's possible)
Another advantage is when a pull request is made, if the merge is automatic it can be seen if the build/test succeeds or not.
If you wish to merge this you have to first activate travis on your branch on https://travis-ci.org and then edit the README.md build status url to point to your branch not mine.
Thank you.