### PR TITLE
Use name() instead of toString() for enum value.

### DIFF
--- a/core/src/main/java/org/sql2o/converters/DefaultEnumConverterFactory.java
+++ b/core/src/main/java/org/sql2o/converters/DefaultEnumConverterFactory.java
@@ -25,7 +25,7 @@ public class DefaultEnumConverterFactory implements EnumConverterFactory {
             }
 
             public Object toDatabaseParam(Enum val) {
-                return val.toString();
+                return val.name();
             }
         };
     }


### PR DESCRIPTION
The javadoc for Enum notes that name() should be used when
correctness depends on getting the exact name of the enum
constant which will not vary from release to release. The
javadoc further encourages overriding the toString() method
when appropriate to provide a more user-friendly name. This
commit fixes the DefaultEnumConverterFactory in cases where
the toString() method is overridden to return something other
than the enum constant.