### PR TITLE
Removal of unused code

### DIFF
--- a/core/src/main/java/org/sql2o/DefaultResultSetHandlerFactory.java
+++ b/core/src/main/java/org/sql2o/DefaultResultSetHandlerFactory.java
@@ -3,7 +3,6 @@ package org.sql2o;
 import org.sql2o.converters.Converter;
 import org.sql2o.converters.ConverterException;
 import org.sql2o.quirks.Quirks;
-import org.sql2o.reflection.Getter;
 import org.sql2o.reflection.Pojo;
 import org.sql2o.reflection.PojoMetadata;
 import org.sql2o.reflection.Setter;
@@ -21,47 +20,6 @@ public class DefaultResultSetHandlerFactory<T> implements ResultSetHandlerFactor
     public DefaultResultSetHandlerFactory(PojoMetadata pojoMetadata, Quirks quirks) {
         this.metadata = pojoMetadata;
         this.quirks = quirks;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Getter getGetter(final Quirks quirks, final String propertyPath, final PojoMetadata metadata) {
-        int index = propertyPath.indexOf('.');
-        if (index <= 0) {
-            // Simple path - fast way
-            final Getter getter = metadata.getPropertyGetterIfExists(propertyPath);
-            // behavior change: do not throw if POJO contains less properties
-            if (getter == null) return null;
-            final Converter converter = quirks.converterOf(getter.getType());
-            // getter without converter
-            if (converter == null) return getter;
-            return new Getter() {
-                public Object getProperty(Object obj) {
-                    try {
-                        return converter.convert(getter.getProperty(obj));
-                    } catch (ConverterException e) {
-                        throw new Sql2oException("Error trying to convert column " + propertyPath + " to type " + getter.getType(), e);
-                    }
-                }
-
-                public Class getType() {
-                    return getter.getType();
-                }
-            };
-        }
-        // dot path - long way
-        // i'm too lazy now to rewrite this case so I just call old unoptimized code...
-        // TODO: rewrite, get rid of POJO class
-        return new Getter() {
-            public Object getProperty(Object obj) {
-                Pojo pojo = new Pojo(metadata, metadata.isCaseSensitive(), obj);
-                return pojo.getProperty(propertyPath, quirks);
-            }
-
-            public Class getType() {
-                // doesn't used anyway
-                return Object.class;
-            }
-        };
     }
 
     @SuppressWarnings("unchecked")
@@ -177,7 +135,6 @@ public class DefaultResultSetHandlerFactory<T> implements ResultSetHandlerFactor
 
     @SuppressWarnings("unchecked")
     private ResultSetHandler<T> newResultSetHandler0(final ResultSetMetaData meta) throws SQLException {
-        final Getter[] getters;
         final Setter[] setters;
         final Converter converter;
         final boolean useExecuteScalar;
@@ -186,19 +143,6 @@ public class DefaultResultSetHandlerFactory<T> implements ResultSetHandlerFactor
 
         converter = quirks.converterOf(metadata.getType());
         final int columnCount = meta.getColumnCount();
-
-        getters = new Getter[columnCount + 1];   // getters[0] is always null
-        for (int i = 1; i <= columnCount; i++) {
-            String colName = quirks.getColumnName(meta, i);
-            // behavior change: do not throw if POJO contains less properties
-            getters[i] = getGetter(quirks, colName, metadata);
-
-            // If more than 1 column is fetched (we cannot fall back to executeScalar),
-            // and the getter doesn't exist, throw exception.
-            if (this.metadata.throwOnMappingFailure && getters[i] == null && columnCount > 1) {
-                 throw new Sql2oException("Could not map " + colName + " to any property.");
-            }
-        }
 
         setters = new Setter[columnCount + 1];   // setters[0] is always null
         for (int i = 1; i <= columnCount; i++) {

--- a/core/src/main/java/org/sql2o/reflection/Pojo.java
+++ b/core/src/main/java/org/sql2o/reflection/Pojo.java
@@ -1,11 +1,11 @@
 package org.sql2o.reflection;
 
+import static org.sql2o.converters.Convert.throwIfNull;
+
 import org.sql2o.Sql2oException;
 import org.sql2o.converters.Converter;
 import org.sql2o.converters.ConverterException;
 import org.sql2o.quirks.Quirks;
-
-import static org.sql2o.converters.Convert.throwIfNull;
 
 /**
  * Used internally to represent a plain old java object.
@@ -27,59 +27,6 @@ public class Pojo {
         this.metadata = metadata;
         ObjectConstructor objectConstructor = metadata.getObjectConstructor();
         object = objectConstructor.newInstance();
-    }
-
-    @SuppressWarnings("unchecked")
-    public Object getProperty(String propertyPath, Quirks quirks){
-        // String.split uses RegularExpression
-        // this is overkill for every column for every row
-        int index = propertyPath.indexOf('.');
-
-        Getter getter;
-
-        if (index > 0) {
-            final String substring = propertyPath.substring(0, index);
-
-            getter = metadata.getPropertyGetter(substring);
-
-            String newPath = propertyPath.substring(index+1);
-
-            Object subValue = this.metadata.getValueOfProperty(substring, this.object);
-
-            if (subValue == null){
-                try {
-                    subValue = getter.getType().newInstance();
-                } catch (InstantiationException e) {
-                    throw new Sql2oException("Could not instantiate a new instance of class "+ getter.getType().toString(), e);
-                } catch (IllegalAccessException e) {
-                    throw new Sql2oException("Could not instantiate a new instance of class "+ getter.getType().toString(), e);
-                }
-
-                return getter.getProperty(this.object);
-            }
-
-            PojoMetadata subMetadata = new PojoMetadata(getter.getType(), this.caseSensitive, this.metadata.isAutoDeriveColumnNames(), this.metadata.getColumnMappings(), this.metadata.throwOnMappingFailure);
-            Pojo subPojo = new Pojo(subMetadata, this.caseSensitive, subValue);
-
-            return subPojo.getProperty(newPath, quirks);
-        }
-        else{
-            getter = metadata.getPropertyGetter(propertyPath);
-
-            Converter converter;
-
-            try {
-                converter = throwIfNull(getter.getType(), quirks.converterOf(getter.getType()));
-            } catch (ConverterException e) {
-                throw new Sql2oException("Cannot convert column " + propertyPath + " to type " + getter.getType(), e);
-            }
-
-            try {
-                return converter.convert(getter.getProperty(this.object));
-            } catch (ConverterException e) {
-                throw new Sql2oException("Error trying to convert column " + propertyPath + " to type " + getter.getType(), e);
-            }
-        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
There is internal code that is not used at all in sql2o.
To facilitate the library maintenance, it should be deleted.
