### PR TITLE
issue 216, cache Quirks per obj / url

### DIFF
--- a/core/src/main/java/org/sql2o/quirks/QuirksDetector.java
+++ b/core/src/main/java/org/sql2o/quirks/QuirksDetector.java
@@ -29,8 +29,7 @@ public class QuirksDetector{
                 return quirksProvider.provide();
             }
         }
-
-        return new NoQuirks();
+        return noQuirks.q;
     }
 
     public static Quirks forObject(Object jdbcObject) {
@@ -44,7 +43,10 @@ public class QuirksDetector{
                 return quirksProvider.provide();
             }
         }
+        return noQuirks.q;
+    }
 
-        return new NoQuirks();
+    private static class noQuirks {
+        static final Quirks q = new NoQuirks();
     }
 }

--- a/core/src/test/java/org/sql2o/quirks/QuirksDetectorTest.java
+++ b/core/src/test/java/org/sql2o/quirks/QuirksDetectorTest.java
@@ -1,0 +1,19 @@
+package org.sql2o.quirks;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class QuirksDetectorTest {
+
+    @Test
+    public void willDefaultToSameInstanceOfNoQuirksIfNothingIsFoundForObj(){
+        Object jdbcObject = new Object();
+        assertSame(QuirksDetector.forObject(jdbcObject), QuirksDetector.forObject(jdbcObject));
+    }
+
+    @Test
+    public void willDefaultToSameInstanceOfNoQuirksIfNothingIsFoundForUrl(){
+        assertSame(QuirksDetector.forURL(""), QuirksDetector.forURL(""));
+    }
+}

--- a/extensions/db2/src/main/java/org/sql2o/quirks/Db2QuirksProvider.java
+++ b/extensions/db2/src/main/java/org/sql2o/quirks/Db2QuirksProvider.java
@@ -16,7 +16,7 @@ package org.sql2o.quirks;
 public class Db2QuirksProvider implements QuirksProvider {
     @Override
     public Quirks provide() {
-        return new Db2Quirks();
+        return db2Quirks.q;
     }
 
     @Override
@@ -29,5 +29,9 @@ public class Db2QuirksProvider implements QuirksProvider {
     @Override
     public boolean isUsableForClass(String className) {
         return className.startsWith("com.ibm.db2.jcc.DB2");
+    }
+
+    private static class db2Quirks {
+        private static final Db2Quirks q = new Db2Quirks();
     }
 }

--- a/extensions/db2/src/test/java/org/sql2o/quirks/Db2QuirksProviderTest.java
+++ b/extensions/db2/src/test/java/org/sql2o/quirks/Db2QuirksProviderTest.java
@@ -1,0 +1,15 @@
+package org.sql2o.quirks;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class Db2QuirksProviderTest {
+
+    @Test
+    public void providerWillReturnTheSameInstance(){
+        Db2QuirksProvider provider = new Db2QuirksProvider();
+        assertSame(provider.provide(), provider.provide());
+    }
+
+}

--- a/extensions/oracle/src/main/java/org/sql2o/quirks/OracleQuirksProvider.java
+++ b/extensions/oracle/src/main/java/org/sql2o/quirks/OracleQuirksProvider.java
@@ -16,7 +16,7 @@ package org.sql2o.quirks;
 public class OracleQuirksProvider implements QuirksProvider {
     @Override
     public Quirks provide() {
-        return new OracleQuirks();
+        return oracleQuirks.q;
     }
 
     @Override
@@ -28,6 +28,10 @@ public class OracleQuirksProvider implements QuirksProvider {
     public boolean isUsableForClass(String className) {
         return className.startsWith("oracle.jdbc.")
                 || className.startsWith("oracle.jdbc.");
+    }
+
+    private static class oracleQuirks {
+        private static final OracleQuirks q = new OracleQuirks();
     }
 
 }

--- a/extensions/oracle/src/test/java/org/sql2o/quirks/OracleQuirksProviderTest.java
+++ b/extensions/oracle/src/test/java/org/sql2o/quirks/OracleQuirksProviderTest.java
@@ -1,0 +1,13 @@
+package org.sql2o.quirks;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OracleQuirksProviderTest {
+    @Test
+    public void providerWillReturnTheSameInstance(){
+        OracleQuirksProvider provider = new OracleQuirksProvider();
+        assertSame(provider.provide(), provider.provide());
+    }
+}

--- a/extensions/postgres/src/main/java/org/sql2o/quirks/PostgresQuirksProvider.java
+++ b/extensions/postgres/src/main/java/org/sql2o/quirks/PostgresQuirksProvider.java
@@ -8,7 +8,7 @@ public class PostgresQuirksProvider implements QuirksProvider {
 
     @Override
     public Quirks provide() {
-        return new PostgresQuirks();
+        return postgresQuirks.q;
     }
 
     @Override
@@ -19,5 +19,9 @@ public class PostgresQuirksProvider implements QuirksProvider {
     @Override
     public boolean isUsableForClass(String className) {
         return className.startsWith("org.postgresql.");
+    }
+
+    private static class postgresQuirks {
+        private static PostgresQuirks q = new PostgresQuirks();
     }
 }

--- a/extensions/postgres/src/test/java/org/sql2o/quirks/PostgresQuirksProviderTest.java
+++ b/extensions/postgres/src/test/java/org/sql2o/quirks/PostgresQuirksProviderTest.java
@@ -1,0 +1,13 @@
+package org.sql2o.quirks;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PostgresQuirksProviderTest {
+    @Test
+    public void providerWillReturnTheSameInstance(){
+        PostgresQuirksProvider provider = new PostgresQuirksProvider();
+        assertSame(provider.provide(), provider.provide());
+    }
+}


### PR DESCRIPTION
This is the possible fix for issue #216 within the master (1.6) branch. See the discussion in the issue.

The idea of the Quirks implementing hash/eq would technically solve the issue today, if the number of Quirk implementations was finite. however the library has opened the system for consumers to supply their own Quirks as well as QuirkProviders. These are defined by interface. So there is no way for the system to require that the various Quirk implementations implement eq/hash and doing so would violate the open/closed principle.

This would invite this same memory leak any time anyone implements a new quirk/provider. 

To get around this I have added a some caches in QuirksDetector in order to only have one quirk for a provider per class or jdbcURI. 
