### PR TITLE
Add generic parameter type in StatementRunnableWithResult<V>

### DIFF
--- a/core/src/main/java/org/sql2o/Sql2o.java
+++ b/core/src/main/java/org/sql2o/Sql2o.java
@@ -181,7 +181,7 @@ public class Sql2o {
      * @return
      */
     @SuppressWarnings("unchecked")
-    public <V> V withConnection(StatementRunnableWithResult runnable, Object argument) {
+    public <V> V withConnection(StatementRunnableWithResult<V> runnable, Object argument) {
         Connection connection = null;
         try{
             connection = open();
@@ -202,7 +202,7 @@ public class Sql2o {
      * @param <V>
      * @return
      */
-    public <V> V withConnection(StatementRunnableWithResult runnable) {
+    public <V> V withConnection(StatementRunnableWithResult<V> runnable) {
         return withConnection(runnable, null);
     }
 
@@ -326,16 +326,16 @@ public class Sql2o {
         connection.commit();
     }
 
-    public <V> V runInTransaction(StatementRunnableWithResult runnableWithResult){
+    public <V> V runInTransaction(StatementRunnableWithResult<V> runnableWithResult){
         return runInTransaction(runnableWithResult, null);
     }
     
-    public <V> V runInTransaction(StatementRunnableWithResult runnableWithResult, Object argument){
+    public <V> V runInTransaction(StatementRunnableWithResult<V> runnableWithResult, Object argument){
         return runInTransaction(runnableWithResult, argument, java.sql.Connection.TRANSACTION_READ_COMMITTED);
     }
 
     @SuppressWarnings("unchecked")
-    public <V> V runInTransaction(StatementRunnableWithResult runnableWithResult, Object argument, int isolationLevel){
+    public <V> V runInTransaction(StatementRunnableWithResult<V> runnableWithResult, Object argument, int isolationLevel){
         Connection connection = this.beginTransaction(isolationLevel);
         Object result;
         

--- a/core/src/main/java/org/sql2o/StatementRunnableWithResult.java
+++ b/core/src/main/java/org/sql2o/StatementRunnableWithResult.java
@@ -2,10 +2,10 @@ package org.sql2o;
 
 /**
  * Represents a method with a {@link Connection} and an optional argument. Implementations of this interface be used as
- * a parameter to one of the {@link Sql2o#runInTransaction(StatementRunnableWithResult)} Sql2o.runInTransaction} overloads,
+ * a parameter to one of the {@link Sql2o#runInTransaction(StatementRunnableWithResult<V>)} Sql2o.runInTransaction} overloads,
  * to run code safely in a transaction.
  */
-public interface StatementRunnableWithResult {
+public interface StatementRunnableWithResult<V> {
 
-    Object run(Connection connection, Object argument) throws Throwable;
+    V run(Connection connection, Object argument) throws Throwable;
 }

--- a/core/src/test/java/org/sql2o/Sql2oTest.java
+++ b/core/src/test/java/org/sql2o/Sql2oTest.java
@@ -695,9 +695,9 @@ public class Sql2oTest extends BaseMemDbTest {
 
     }
 
-    private static class runnerWithResultTester implements StatementRunnableWithResult{
+    private static class runnerWithResultTester implements StatementRunnableWithResult<List<Integer>> {
 
-        public Object run(Connection connection, Object argument) throws Throwable {
+        public List<Integer> run(Connection connection, Object argument) throws Throwable {
             String[] vals = (String[])argument;
             List<Integer> keys = new ArrayList<Integer>();
             for (String val : vals){
@@ -1199,8 +1199,8 @@ public class Sql2oTest extends BaseMemDbTest {
             }
         });
 
-        List<User> users = sql2o.withConnection(new StatementRunnableWithResult() {
-            public Object run(Connection connection, Object argument) throws Throwable {
+        List<User> users = sql2o.withConnection(new StatementRunnableWithResult<List<User>>() {
+            public List<User> run(Connection connection, Object argument) throws Throwable {
                 return sql2o.createQuery("select * from User").executeAndFetch(User.class);
             }
         });


### PR DESCRIPTION
It would be convenient to add parameter type for `StatementRunnableWithResult`.