### PR TITLE
Fix columnsMappings

### DIFF
--- a/core/src/main/java/org/sql2o/Query.java
+++ b/core/src/main/java/org/sql2o/Query.java
@@ -526,7 +526,7 @@ public class Query implements AutoCloseable {
         if(builder==null) builder=new DefaultResultSetHandlerFactoryBuilder();
         builder.setAutoDeriveColumnNames(this.autoDeriveColumnNames);
         builder.setCaseSensitive(this.caseSensitive);
-        builder.setColumnMappings(this.columnMappings);
+        builder.setColumnMappings(this.getColumnMappings());
         builder.setQuirks(quirks);
         builder.throwOnMappingError(this.throwOnMappingFailure);
         return builder.newFactory(returnType);


### PR DESCRIPTION
The factory was always using the lowercase version of `columnMappings` leading to errors for property names like `tableName, createdAt, etc`.