### PR TITLE
possibility to set default transaction isolation level

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,6 +85,18 @@
             <artifactId>hsqldb</artifactId>
             <version>2.2.8</version>
         </dependency>
+        <dependency>
+            <scope>test</scope>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.8.11.2</version>
+        </dependency>
+        <dependency>
+            <scope>test</scope>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>2.4.5</version>
+        </dependency>
         <!-- Uncomment to run oracle tests.  -->
         <!--
         <dependency>

--- a/core/src/main/java/org/sql2o/Sql2o.java
+++ b/core/src/main/java/org/sql2o/Sql2o.java
@@ -29,6 +29,7 @@ public class Sql2o {
     private final DataSource dataSource;
     private Map<String, String> defaultColumnMappings;
     private boolean defaultCaseSensitive;
+    private int defaultTransactionIsolationLevel;
 
     private final static Logger logger = LocalLoggerFactory.getLogger(Sql2o.class);
 
@@ -76,6 +77,7 @@ public class Sql2o {
         this.dataSource = dataSource;
         this.quirks=quirks;
         this.defaultColumnMappings = new HashMap<String, String>();
+        this.defaultTransactionIsolationLevel = java.sql.Connection.TRANSACTION_READ_COMMITTED;
     }
 
     public Quirks getQuirks() {
@@ -125,6 +127,24 @@ public class Sql2o {
      */
     public void setDefaultCaseSensitive(boolean defaultCaseSensitive) {
         this.defaultCaseSensitive = defaultCaseSensitive;
+    }
+    
+    /**
+     * Gets the default transaction isolation level.
+     * @return Constant value from {@link java.sql.Connection}
+     */
+    public int getDefaultTransactionIsolationLevel() {
+    
+        return defaultTransactionIsolationLevel;
+    }
+    
+    /**
+     * Sets the default transaction isolation level.
+     * @param defaultTransactionIsolationLevel Constant value from {@link java.sql.Connection}
+     */
+    public void setDefaultTransactionIsolationLevel(int defaultTransactionIsolationLevel) {
+    
+        this.defaultTransactionIsolationLevel = defaultTransactionIsolationLevel;
     }
 
     /**
@@ -262,15 +282,17 @@ public class Sql2o {
 
         return connection;
     }
-
+    
     /**
-     * Begins a transaction with isolation level {@link java.sql.Connection#TRANSACTION_READ_COMMITTED}. Every statement executed on the return {@link Connection}
+     * Begins a transaction with default isolation level (which is {@link java.sql.Connection#TRANSACTION_READ_COMMITTED}
+     * if not modified by {@link Sql2o#setDefaultTransactionIsolationLevel(int)}).
+     * Every statement executed on the return {@link Connection}
      * instance, will be executed in the transaction. It is very important to always call either the {@link org.sql2o.Connection#commit()}
      * method or the {@link org.sql2o.Connection#rollback()} method to close the transaction. Use proper try-catch logic.
      * @return the {@link Connection} instance to use to run statements in the transaction.
      */
     public Connection beginTransaction(){
-        return this.beginTransaction(java.sql.Connection.TRANSACTION_READ_COMMITTED);
+        return this.beginTransaction(defaultTransactionIsolationLevel);
     }
 
     /**

--- a/core/src/test/java/org/sql2o/SQLiteTransactionalTest.java
+++ b/core/src/test/java/org/sql2o/SQLiteTransactionalTest.java
@@ -1,0 +1,142 @@
+package org.sql2o;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.sql.DataSource;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.sql2o.data.Table;
+import org.sqlite.javax.SQLiteConnectionPoolDataSource;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+public class SQLiteTransactionalTest {
+
+    private static final String DATABASE_JDBC_URL = "jdbc:sqlite::memory:";
+
+    DataSource dataSource;
+
+    private void initDataSource() {
+
+        SQLiteConnectionPoolDataSource sqLiteDataSource = new SQLiteConnectionPoolDataSource();
+        sqLiteDataSource.setUrl(DATABASE_JDBC_URL);
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDataSource(sqLiteDataSource);
+        // Using single connection pool partly to keep in memory database alive
+        hikariConfig.setMaximumPoolSize(1);
+        dataSource = new HikariDataSource(hikariConfig);
+    }
+
+    private void initDatabase() {
+
+        java.sql.Connection connection = null;
+
+        try {
+
+            connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+            Statement statement = connection.createStatement();
+
+            statement.execute("create table entity ("
+                    + "id int identity primary key, "
+                    + "text varchar(255))");
+
+            connection.commit();
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+            try {
+                connection.rollback();
+            } catch (SQLException e2) {
+                e2.printStackTrace();
+            }
+        } finally {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Before
+    public void beforeTest() {
+
+        initDataSource();
+        initDatabase();
+    }
+
+    @After
+    public void afterTest() {
+
+        ((HikariDataSource) dataSource).close();
+    }
+
+    @Test
+    public void test_default_transaction_isolation_level_error() {
+
+        Sql2o sql2o = new Sql2o(dataSource);
+        try {
+            sql2o.beginTransaction();
+            Assert.fail();
+        } catch (Sql2oException e) {
+            Assert.assertEquals("SQLite supports only TRANSACTION_SERIALIZABLE and TRANSACTION_READ_UNCOMMITTED.",
+                    e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void test_with_appropriate_default_transaction_isolation_level() {
+        
+        int defaultTransactionIsolationLevel = java.sql.Connection.TRANSACTION_SERIALIZABLE;
+
+        Sql2o sql2o = new Sql2o(dataSource);
+        sql2o.setDefaultTransactionIsolationLevel(defaultTransactionIsolationLevel);
+        
+        Table table;
+
+        try (Connection connection = sql2o.beginTransaction()) {
+            executeInsert(connection);
+            // no commit
+        }
+        
+        table = executeQuery(sql2o);
+        
+        Assert.assertEquals(0, table.rows().size());
+
+        try (Connection connection = sql2o.beginTransaction()) {
+            executeInsert(connection);
+            connection.commit();
+        }
+        
+        table = executeQuery(sql2o);
+        
+        Assert.assertEquals(1, table.rows().size());
+        Assert.assertEquals(table.rows().get(0).getObject("id"), 1);
+        Assert.assertEquals(table.rows().get(0).getObject("text"), "FooBarTok");
+        
+        Assert.assertEquals(defaultTransactionIsolationLevel, sql2o.getDefaultTransactionIsolationLevel());
+    }
+
+    private Table executeQuery(Sql2o sql2o) {
+
+        Table table;
+        try (Connection connection = sql2o.open()) {
+            table = connection.createQuery("select * from entity").executeAndFetchTable();
+        }
+        return table;
+    }
+
+    private void executeInsert(Connection connection) {
+
+        connection.createQuery("insert into entity (id, text) values (:id, :text)")
+            .addParameter("id", 1)
+            .addParameter("text", "FooBarTok")
+            .executeUpdate();
+    }
+}


### PR DESCRIPTION
I felt the need for this as SQLite databases don't support the standard "java.sql.Connection.TRANSACTION_READ_COMMITTED".
But this can probably be interesting for some other situations as well.

It is then tested with an in memory SQLite database.
