### PR TITLE
Add substitution

### DIFF
--- a/core/src/main/java/org/sql2o/Query.java
+++ b/core/src/main/java/org/sql2o/Query.java
@@ -196,6 +196,67 @@ public class Query implements AutoCloseable {
         return this;
     }
 
+    /**
+     * Replace the diamond parameter <param> with the string
+     * Be careful of sql injection!
+     */
+    public Query addSubstitution(String name, String substitution) {
+        parsedQuery = replaceParam(parsedQuery, name, substitution);
+        return this;
+    }
+
+    /**
+     * Replace the diamond parameter <param> with the string
+     * Be careful of sql injection!
+     */
+    public Query addSubstitution(String name, int substitution) {
+        parsedQuery = replaceParam(parsedQuery, name, String.valueOf(substitution));
+        return this;
+    }
+
+    /**
+     * Replace the diamond parameter <param> with the string
+     * Be careful of sql injection!
+     */
+    public Query addSubstitution(String name, long substitution) {
+        parsedQuery = replaceParam(parsedQuery, name, String.valueOf(substitution));
+        return this;
+    }
+
+    /**
+     * Replace the diamond parameter <param> with the string
+     * Be careful of sql injection!
+     */
+    public Query addSubstitution(String name, double substitution) {
+        parsedQuery = replaceParam(parsedQuery, name, String.valueOf(substitution));
+        return this;
+    }
+
+
+    /**
+     * Replace the diamond parameter <param> with a comma separated string
+     * Be careful of sql injection!
+     */
+    public Query addSubstitution(String name, Collection<?> substitution) {
+        StringBuilder sb = new StringBuilder();
+        for (Object o : substitution) {
+            sb.append(o.toString()).append(",");
+        }
+        if (sb.length() > 0) {
+            sb.setLength(sb.length() - 1);
+        }
+        parsedQuery = replaceParam(parsedQuery, name, sb.toString());
+        return this;
+    }
+
+    private String replaceParam(String sql, String name, String replace) {
+        String param = "<" + name + ">";
+        if (sql.contains(param)) {
+            sql = sql.replace(param, replace);
+        }
+        return sql;
+    }
+
     @SuppressWarnings("unchecked")
     public Query addParameter(String name, Object value) {
         return value == null

--- a/core/src/test/java/org/sql2o/Sql2oTest.java
+++ b/core/src/test/java/org/sql2o/Sql2oTest.java
@@ -1301,6 +1301,25 @@ public class Sql2oTest extends BaseMemDbTest {
     }
 
     @Test
+    public void testSubstitution() {
+        try (Connection connection = sql2o.open()) {
+            connection.createQuery("create table testSubstitution(id integer primary key, val clob)")
+                    .executeUpdate();
+
+            connection.createQuery("insert into testSubstitution (id, val) values (<id>, :val)")
+                    .addSubstitution("id", 1)
+                    .addParameter("val", "something")
+                    .executeUpdate();
+
+            String val = connection.createQuery("select val from testSubstitution where id = <id>")
+                    .addSubstitution("id", 1)
+                    .executeScalar(String.class);
+
+            assertThat(val, is(equalTo("something")));
+        }
+    }
+
+    @Test
     public void testBindInIteration() {
         try (Connection connection = sql2o.open()) {
             createAndFillUserTable(connection, true);

--- a/core/src/test/java/org/sql2o/Sql2oTest.java
+++ b/core/src/test/java/org/sql2o/Sql2oTest.java
@@ -1322,15 +1322,15 @@ public class Sql2oTest extends BaseMemDbTest {
     @Test
     public void testSubstitutionList() {
         try (Connection connection = sql2o.open()) {
-            connection.createQuery("create table testSubstitution(id integer primary key, val clob)")
+            connection.createQuery("create table testSubstitutionList(id integer primary key, val clob)")
                     .executeUpdate();
 
-            connection.createQuery("insert into testSubstitution (id, val) values (<id>, :val)")
+            connection.createQuery("insert into testSubstitutionList (id, val) values (<id>, :val)")
                     .addSubstitution("id", 1)
                     .addParameter("val", "something")
                     .executeUpdate();
 
-            connection.createQuery("insert into testSubstitution (id, val) values (<id>, :val)")
+            connection.createQuery("insert into testSubstitutionList (id, val) values (<id>, :val)")
                     .addSubstitution("id", 2)
                     .addParameter("val", "something2")
                     .executeUpdate();
@@ -1338,7 +1338,7 @@ public class Sql2oTest extends BaseMemDbTest {
             List<Integer> id = new ArrayList<>();
             id.add(1);
             id.add(2);
-            List<String> val = connection.createQuery("select val from testSubstitution where id in (<id>)")
+            List<String> val = connection.createQuery("select val from testSubstitutionList where id in (<id>)")
                     .addSubstitution("id", id)
                     .executeScalarList(String.class);
 


### PR DESCRIPTION
MSSQL only supports 2100 parameters for prepared statements. Which makes
string substitution a better option for in clause.

String substitution is nice-to-have, despite the risk of sql injection,
and is a feature in jdbi.

The addSubstitution simply replaces the param in the sql with a string.
