### PR TITLE
Bind type parameter to class in getKey

### DIFF
--- a/core/src/main/java/org/sql2o/Connection.java
+++ b/core/src/main/java/org/sql2o/Connection.java
@@ -194,7 +194,7 @@ public class Connection implements AutoCloseable, Closeable {
     }
 
     @SuppressWarnings("unchecked") // need to change Convert
-    public <V> V getKey(Class returnType){
+    public <V> V getKey(Class<V> returnType){
         final Quirks quirks = this.sql2o.getQuirks();
         Object key = getKey();
         try {


### PR DESCRIPTION
Not sure why this was missed out (it is in `getKeys(Class klass)`). I've ended up needing to do

```
query.executeUpdate().<Integer>getKey(Integer.class);
```

as the type paramter doesn't bind properly at the moment.