### PR TITLE
External connection/transaction management

### DIFF
--- a/core/src/main/java/org/sql2o/Connection.java
+++ b/core/src/main/java/org/sql2o/Connection.java
@@ -1,5 +1,6 @@
 package org.sql2o;
 
+import org.sql2o.connectionsources.ConnectionSource;
 import org.sql2o.converters.Converter;
 import org.sql2o.converters.ConverterException;
 import org.sql2o.logging.LocalLoggerFactory;
@@ -24,6 +25,7 @@ public class Connection implements AutoCloseable, Closeable {
     
     private final static Logger logger = LocalLoggerFactory.getLogger(Connection.class);
 
+    private ConnectionSource connectionSource;
     private java.sql.Connection jdbcConnection;
     private Sql2o sql2o;
 
@@ -57,7 +59,11 @@ public class Connection implements AutoCloseable, Closeable {
     final boolean autoClose;
 
     Connection(Sql2o sql2o, boolean autoClose) {
+        this(sql2o, null, autoClose);
+    }
 
+    Connection(Sql2o sql2o, ConnectionSource connectionSource, boolean autoClose) {
+        this.connectionSource = connectionSource != null ? connectionSource : sql2o.getConnectionSource();
         this.autoClose = autoClose;
         this.sql2o = sql2o;
         createConnection();
@@ -295,7 +301,7 @@ public class Connection implements AutoCloseable, Closeable {
 
     private void createConnection(){
         try{
-            this.jdbcConnection = this.sql2o.getDataSource().getConnection();
+            this.jdbcConnection = connectionSource.getConnection();
         }
         catch(Exception ex){
             throw new Sql2oException("Could not acquire a connection from DataSource - " + ex.getMessage(), ex);

--- a/core/src/main/java/org/sql2o/connectionsources/ConnectionSource.java
+++ b/core/src/main/java/org/sql2o/connectionsources/ConnectionSource.java
@@ -1,0 +1,14 @@
+package org.sql2o.connectionsources;
+
+import java.sql.SQLException;
+
+/**
+ * An abstraction layer for providing jdbc connection
+ * to use from {@link org.sql2o.Connection}
+ * Created by nickl on 09.01.17.
+ */
+public interface ConnectionSource {
+
+    java.sql.Connection getConnection() throws SQLException;
+
+}

--- a/core/src/main/java/org/sql2o/connectionsources/ConnectionSources.java
+++ b/core/src/main/java/org/sql2o/connectionsources/ConnectionSources.java
@@ -1,0 +1,31 @@
+package org.sql2o.connectionsources;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Predefined implementations of {@link ConnectionSource}
+ * Created by nickl on 09.01.17.
+ */
+public class ConnectionSources {
+
+    private ConnectionSources() {
+    }
+
+    /**
+     * A ConnectionSource that will wrap externally managed connection
+     * with proxy that will omit {@link Connection#close()} or {@link Connection#commit()} calls.
+     * This is useful to make {@link org.sql2o.Connection} work with externally managed transactions
+     * @param connection connection to wrap
+     * @return a connection wrapper that represent a nested connection
+     */
+    public static ConnectionSource join(final Connection connection) {
+        return new ConnectionSource() {
+            @Override
+            public Connection getConnection() throws SQLException {
+                return new NestedConnection(connection);
+            }
+        };
+    }
+
+}

--- a/core/src/main/java/org/sql2o/connectionsources/DataSourceConnectionSource.java
+++ b/core/src/main/java/org/sql2o/connectionsources/DataSourceConnectionSource.java
@@ -1,0 +1,32 @@
+package org.sql2o.connectionsources;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * The default implementation of {@link ConnectionSource},
+ * Simply delegates all calls to specified {@link DataSource }
+ * Created by nickl on 09.01.17.
+ */
+public class DataSourceConnectionSource implements ConnectionSource {
+
+    private final DataSource dataSource;
+
+    /**
+     * Creates a ConnectionSource that gets connection from specified {@link DataSource }
+     * @param dataSource a DataSource to get connections from
+     */
+    public DataSourceConnectionSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+}

--- a/core/src/main/java/org/sql2o/connectionsources/NestedConnection.java
+++ b/core/src/main/java/org/sql2o/connectionsources/NestedConnection.java
@@ -1,0 +1,61 @@
+package org.sql2o.connectionsources;
+
+import org.sql2o.logging.LocalLoggerFactory;
+import org.sql2o.logging.Logger;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Created by nickl on 09.01.17.
+ */
+class NestedConnection extends WrappedConnection {
+
+    private final static Logger logger = LocalLoggerFactory.getLogger(NestedConnection.class);
+
+    private boolean autocommit = true;
+
+    NestedConnection(Connection source) {
+        super(source);
+    }
+
+
+    private boolean commited = false;
+
+    @Override
+    public void commit() throws SQLException {
+        commited = true;
+        //do nothing, parent connection should be committed
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        if(!commited) {
+            logger.warn("rollback of nested transaction leads to rollback of parent transaction. Maybe it is not wat you want.");
+            super.rollback(); //probably it's worth to use savepoints
+        }
+    }
+
+    @Override
+    public void close() throws SQLException {
+        //do nothing, parent connection should be closed by someone who cares
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+        //do nothing, parent connection should be configured
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        return autocommit;
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        this.autocommit = autoCommit;
+    }
+
+
+
+}

--- a/core/src/main/java/org/sql2o/connectionsources/WrappedConnection.java
+++ b/core/src/main/java/org/sql2o/connectionsources/WrappedConnection.java
@@ -1,0 +1,291 @@
+package org.sql2o.connectionsources;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * Simple {@link Connection wrapper}
+ * Created by nickl on 09.01.17.
+ */
+public class WrappedConnection implements Connection {
+
+
+    private Connection source;
+
+
+    public WrappedConnection(Connection source) {
+        this.source = source;
+    }
+
+    @Override
+    public Statement createStatement() throws SQLException {
+        return source.createStatement();
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+        return source.prepareStatement(sql);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        return source.prepareCall(sql);
+    }
+
+    @Override
+    public String nativeSQL(String sql) throws SQLException {
+        return source.nativeSQL(sql);
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        source.setAutoCommit(autoCommit);
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        return source.getAutoCommit();
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        source.commit();
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        source.rollback();
+    }
+
+    @Override
+    public void close() throws SQLException {
+        source.close();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return source.isClosed();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return source.getMetaData();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        source.setReadOnly(readOnly);
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        return source.isReadOnly();
+    }
+
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+        source.setCatalog(catalog);
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+        return source.getCatalog();
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+        source.setTransactionIsolation(level);
+    }
+
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+        return source.getTransactionIsolation();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return source.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        source.clearWarnings();
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+        return source.createStatement(resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return source.prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return source.prepareCall(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        return source.getTypeMap();
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        source.setTypeMap(map);
+    }
+
+    @Override
+    public void setHoldability(int holdability) throws SQLException {
+        source.setHoldability(holdability);
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        return source.getHoldability();
+    }
+
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+        return source.setSavepoint();
+    }
+
+    @Override
+    public Savepoint setSavepoint(String name) throws SQLException {
+        return source.setSavepoint(name);
+    }
+
+    @Override
+    public void rollback(Savepoint savepoint) throws SQLException {
+        source.rollback(savepoint);
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        source.releaseSavepoint(savepoint);
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return source.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return source.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return source.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+        return source.prepareStatement(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        return source.prepareStatement(sql, columnIndexes);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+        return source.prepareStatement(sql, columnNames);
+    }
+
+    @Override
+    public Clob createClob() throws SQLException {
+        return source.createClob();
+    }
+
+    @Override
+    public Blob createBlob() throws SQLException {
+        return source.createBlob();
+    }
+
+    @Override
+    public NClob createNClob() throws SQLException {
+        return source.createNClob();
+    }
+
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+        return source.createSQLXML();
+    }
+
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        return source.isValid(timeout);
+    }
+
+    @Override
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+        source.setClientInfo(name, value);
+    }
+
+    @Override
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+        source.setClientInfo(properties);
+    }
+
+    @Override
+    public String getClientInfo(String name) throws SQLException {
+        return source.getClientInfo(name);
+    }
+
+    @Override
+    public Properties getClientInfo() throws SQLException {
+        return source.getClientInfo();
+    }
+
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        return source.createArrayOf(typeName, elements);
+    }
+
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        return source.createStruct(typeName, attributes);
+    }
+
+    @Override
+    public void setSchema(String schema) throws SQLException {
+        source.setSchema(schema);
+    }
+
+    @Override
+    public String getSchema() throws SQLException {
+        return source.getSchema();
+    }
+
+    @Override
+    public void abort(Executor executor) throws SQLException {
+        source.abort(executor);
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        source.setNetworkTimeout(executor, milliseconds);
+    }
+
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+        return source.getNetworkTimeout();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return source.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return source.isWrapperFor(iface);
+    }
+}


### PR DESCRIPTION
My version of "Support for Spring transaction management" (#153) pull request:

 * Decoupling of sql2o's `Connection` and `DataSource`. That allows to substitute source of `java.sql.Connection` for specific `open()` and `beginTransaction()` calls. This adds possibility to use `Sql2o` instance with externally managed `java.sql.Connection`.
 * A class for creating "nested" connection proxies for working with nested transactions (probably fixes #89)

Usage sample (included also in test) looks like:
```java
try (Connection globalConnection = sql2o.beginTransaction()) {
    java.sql.Connection globalTransaction = globalConnection.getJdbcConnection();

    try(Connection connection = sql2o.beginTransaction(join(globalTransaction)) ) {
       ...
        connection.commit();
    }

    try(Connection connection = sql2o.beginTransaction(join(globalTransaction)) ) {
       ...
        connection.commit();
    }

    globalConnection.commit();
}
```

PS:
Actually, I think that `Sql2o` should not (or at least should be able to not) connect to database itself. It will be great if user can just plug `Sql2o` in any part of existing code, where he has `java.sql.Connection`, not be forced to create DataSource instance. It will be especially useful in languages like Scala/Kotlin/Groovy where extension-methods are present and user will be able to just "pimp" `java.sql.Connection` with `Sql2o`.

If you like this idea I will try to continue working in this direction for sql2o 2.0 for example