### PR TITLE
Ideas for 2.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.sql2o</groupId>
         <artifactId>sql2o-parent</artifactId>
-        <version>1.6.0-RC4-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <developers>
         <developer>

--- a/core/src/main/java/org/sql2o/BaseConnection.java
+++ b/core/src/main/java/org/sql2o/BaseConnection.java
@@ -1,0 +1,321 @@
+package org.sql2o;
+
+import org.sql2o.converters.Converter;
+import org.sql2o.converters.ConverterException;
+import org.sql2o.logging.LocalLoggerFactory;
+import org.sql2o.logging.Logger;
+import org.sql2o.quirks.Quirks;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+
+import static java.util.Objects.requireNonNull;
+import static org.sql2o.converters.Convert.throwIfNull;
+
+/**
+ * Created by nickl on 20.01.17.
+ */
+class BaseConnection implements Connection {
+    private final static Logger logger = LocalLoggerFactory.getLogger(BaseConnection.class);
+    protected final Settings settings;
+    private final boolean autoClose;
+    private final Set<Statement> statements = new HashSet<>();
+    protected java.sql.Connection jdbcConnection;
+    private Integer result = null;
+    private int[] batchResult = null;
+    private List<Object> keys;
+    private boolean canGetKeys;
+    private boolean rollbackOnException = true;
+    private boolean rollbackOnClose = true;
+
+    BaseConnection(Settings settings, boolean autoClose) {
+        this.settings = requireNonNull(settings, "settings can't be null");
+        this.autoClose = autoClose;
+    }
+
+    BaseConnection(java.sql.Connection jdbcConnection, Settings settings, boolean autoClose) {
+       this(settings, autoClose);
+       this.jdbcConnection = Objects.requireNonNull(jdbcConnection, "jdbcConnection can't be null");
+    }
+
+    @Override
+    public boolean isRollbackOnException() {
+        return rollbackOnException;
+    }
+
+    @Override
+    public Connection setRollbackOnException(boolean rollbackOnException) {
+        this.rollbackOnException = rollbackOnException;
+        return this;
+    }
+
+    @Override
+    public boolean isRollbackOnClose() {
+        return rollbackOnClose;
+    }
+
+    @Override
+    public Connection setRollbackOnClose(boolean rollbackOnClose) {
+        this.rollbackOnClose = rollbackOnClose;
+        return this;
+    }
+
+
+    public void onException() {
+        if (isRollbackOnException()) {
+            rollback(this.autoClose);
+        }
+    }
+
+    @Override
+    public java.sql.Connection getJdbcConnection() {
+        return jdbcConnection;
+    }
+
+    @Override
+    public Settings getSettings() {
+        return settings;
+    }
+
+    @Override
+    public Query createQuery(String queryText, boolean returnGeneratedKeys){
+        return new Query(this, queryText, returnGeneratedKeys);
+    }
+
+    @Override
+    public Query createQuery(String queryText, String... columnNames) {
+        return new Query(this, queryText, columnNames);
+    }
+
+    @Override
+    public Query createQuery(String queryText){
+        boolean returnGeneratedKeys = this.settings.getQuirks().returnGeneratedKeysByDefault();
+        return createQuery(queryText, returnGeneratedKeys);
+    }
+
+    @Override
+    public Query createQueryWithParams(String queryText, Object... paramValues){
+        // due to #146, creating a query will not create a statement anymore;
+        // the PreparedStatement will only be created once the query needs to be executed
+        // => there is no need to handle the query closing here anymore since there is nothing to close
+        return createQuery(queryText)
+                .withParams(paramValues);
+    }
+
+    @Override
+    public void rollback(){
+       this.rollback(true);
+    }
+
+    @Override
+    public Connection rollback(boolean closeConnection){
+        try {
+            jdbcConnection.rollback();
+        }
+        catch (SQLException e) {
+            logger.warn("Could not roll back transaction. message: {}", e);
+        }
+        finally {
+            if(closeConnection) this.closeJdbcConnection();
+        }
+        return this;
+    }
+
+    @Override
+    public void commit(){
+        this.commit(true);
+    }
+
+    @Override
+    public Connection commit(boolean closeConnection){
+        try {
+            jdbcConnection.commit();
+        }
+        catch (SQLException e) {
+            throw new Sql2oException(e);
+        }
+        finally {
+            if(closeConnection)
+                this.closeJdbcConnection();
+        }
+        return this;
+    }
+
+    @Override
+    public int getResult(){
+        if (this.result == null){
+            throw new Sql2oException("It is required to call executeUpdate() method before calling getResult().");
+        }
+        return this.result;
+    }
+
+
+    public void setResult(int result){
+        this.result = result;
+    }
+
+    @Override
+    public int[] getBatchResult() {
+        if (this.batchResult == null){
+            throw new Sql2oException("It is required to call executeBatch() method before calling getBatchResult().");
+        }
+        return this.batchResult;
+    }
+
+
+    public void setBatchResult(int[] value) {
+        this.batchResult = value;
+    }
+
+
+    public void setKeys(ResultSet rs) throws SQLException {
+        if (rs == null){
+            this.keys = null;
+            return;
+        }
+        this.keys = new ArrayList<Object>();
+        while(rs.next()){
+            this.keys.add(rs.getObject(1));
+        }
+    }
+
+    @Override
+    public Object getKey(){
+        if (!this.canGetKeys){
+            throw new Sql2oException("Keys were not fetched from database. Please set the returnGeneratedKeys parameter in the createQuery() method to enable fetching of generated keys.");
+        }
+        if (this.keys != null && this.keys.size() > 0){
+            return  keys.get(0);
+        }
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // need to change Convert
+    public <V> V getKey(Class returnType){
+        final Quirks quirks = this.settings.getQuirks();
+        Object key = getKey();
+        try {
+            Converter<V> converter = throwIfNull(returnType, quirks.converterOf(returnType));
+            return converter.convert(key);
+        } catch (ConverterException e) {
+            throw new Sql2oException("Exception occurred while converting value from database to type " + returnType.toString(), e);
+        }
+    }
+
+    @Override
+    public Object[] getKeys(){
+        if (!this.canGetKeys){
+            throw new Sql2oException("Keys where not fetched from database. Please set the returnGeneratedKeys parameter in the createQuery() method to enable fetching of generated keys.");
+        }
+        if (this.keys != null){
+            return this.keys.toArray();
+        }
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // need to change Convert
+    public <V> List<V> getKeys(Class<V> returnType) {
+        final Quirks quirks = settings.getQuirks();
+        if (!this.canGetKeys) {
+            throw new Sql2oException("Keys where not fetched from database. Please set the returnGeneratedKeys parameter in the createQuery() method to enable fetching of generated keys.");
+        }
+
+        if (this.keys != null) {
+            try {
+                Converter<V> converter = throwIfNull(returnType, quirks.converterOf(returnType));
+
+                List<V> convertedKeys = new ArrayList<V>(this.keys.size());
+
+                for (Object key : this.keys) {
+                    convertedKeys.add(converter.convert(key));
+                }
+
+                return convertedKeys;
+            }
+            catch (ConverterException e) {
+                throw new Sql2oException("Exception occurred while converting value from database to type " + returnType.toString(), e);
+            }
+        }
+
+        return null;
+    }
+
+
+    public void setCanGetKeys(boolean canGetKeys) {
+        this.canGetKeys = canGetKeys;
+    }
+
+
+    public void registerStatement(Statement statement){
+        statements.add(statement);
+    }
+
+
+    public void removeStatement(Statement statement){
+        statements.remove(statement);
+    }
+
+    @Override
+    public void close() {
+        boolean connectionIsClosed;
+        try {
+            connectionIsClosed = jdbcConnection.isClosed();
+        } catch (SQLException e) {
+            throw new Sql2oException("Sql2o encountered a problem while trying to determine whether the connection is closed.", e);
+        }
+
+        if (!connectionIsClosed) {
+
+            for (Statement statement : statements) {
+                try {
+                    settings.getQuirks().closeStatement(statement);
+                } catch (Throwable e) {
+                    logger.warn("Could not close statement.", e);
+                }
+            }
+            statements.clear();
+
+            boolean rollback = rollbackOnClose;
+            if (rollback) {
+                try {
+                    rollback = !jdbcConnection.getAutoCommit();
+                } catch (SQLException e) {
+                    logger.warn("Could not determine connection auto commit mode.", e);
+                }
+            }
+
+            // if in transaction, rollback, otherwise just close
+            if (rollback) {
+                this.rollback(true);
+            }
+            else {
+                this.closeJdbcConnection();
+            }
+        }
+    }
+
+
+    public void closeIfNecessary() {
+        try{
+            if (this.autoClose){
+                this.close();
+            }
+        }
+        catch (Exception ex){
+            throw new Sql2oException("Error while attempting to close connection", ex);
+        }
+    }
+
+    private void closeJdbcConnection() {
+        try {
+            jdbcConnection.close();
+        }
+        catch (SQLException e) {
+            logger.warn("Could not close connection. message: {}", e);
+        }
+    }
+}

--- a/core/src/main/java/org/sql2o/Query.java
+++ b/core/src/main/java/org/sql2o/Query.java
@@ -26,7 +26,7 @@ public class Query implements AutoCloseable {
 
     private final static Logger logger = LocalLoggerFactory.getLogger(Query.class);
 
-    private Connection connection;
+    private BaseConnection connection;
     private Map<String, String> caseSensitiveColumnMappings;
     private Map<String, String> columnMappings;
     private PreparedStatement preparedStatement = null;
@@ -49,15 +49,15 @@ public class Query implements AutoCloseable {
         return parsedQuery;
     }
 
-    public Query(Connection connection, String queryText, boolean returnGeneratedKeys) {
+    Query(BaseConnection connection, String queryText, boolean returnGeneratedKeys) {
         this(connection, queryText, returnGeneratedKeys, null);
     }
 
-    public Query(Connection connection, String queryText, String[] columnNames) {
+    Query(BaseConnection connection, String queryText, String[] columnNames) {
         this(connection, queryText, false, columnNames);
     }
 
-    private Query(Connection connection, String queryText, boolean returnGeneratedKeys, String[] columnNames) {
+    private Query(BaseConnection connection, String queryText, boolean returnGeneratedKeys, String[] columnNames) {
         this.connection = connection;
         this.returnGeneratedKeys = returnGeneratedKeys;
         this.columnNames = columnNames;
@@ -491,7 +491,7 @@ public class Query implements AutoCloseable {
                 if (this.isAutoCloseConnection()){
                     connection.close();
                 } else {
-                    closeConnectionIfNecessary();
+                    connection.closeIfNecessary();
                 }
             }
         }
@@ -662,7 +662,7 @@ public class Query implements AutoCloseable {
             throw new Sql2oException("Error in executeUpdate, " + ex.getMessage(), ex);
         }
         finally {
-            closeConnectionIfNecessary();
+            connection.closeIfNecessary();
         }
 
         long end = System.currentTimeMillis();
@@ -698,7 +698,7 @@ public class Query implements AutoCloseable {
             throw new Sql2oException("Database error occurred while running executeScalar: " + e.getMessage(), e);
         }
         finally{
-            closeConnectionIfNecessary();
+            connection.closeIfNecessary();
         }
 
     }
@@ -861,7 +861,7 @@ public class Query implements AutoCloseable {
             throw new Sql2oException("Error while executing batch operation: " + e.getMessage(), e);
         }
         finally {
-            closeConnectionIfNecessary();
+            connection.closeIfNecessary();
         }
 
         long end = System.currentTimeMillis();
@@ -902,19 +902,6 @@ public class Query implements AutoCloseable {
         this.columnMappings.put(columnName.toLowerCase(), propertyName.toLowerCase());
 
         return this;
-    }
-
-    /************** private stuff ***************/
-
-    private void closeConnectionIfNecessary(){
-        try{
-            if (connection.autoClose){
-                connection.close();
-            }
-        }
-        catch (Exception ex){
-            throw new Sql2oException("Error while attempting to close connection", ex);
-        }
     }
 
     private void logExecution() {

--- a/core/src/main/java/org/sql2o/Query.java
+++ b/core/src/main/java/org/sql2o/Query.java
@@ -61,13 +61,13 @@ public class Query implements AutoCloseable {
         this.connection = connection;
         this.returnGeneratedKeys = returnGeneratedKeys;
         this.columnNames = columnNames;
-        this.setColumnMappings(connection.getSql2o().getDefaultColumnMappings());
-        this.caseSensitive = connection.getSql2o().isDefaultCaseSensitive();
+        this.setColumnMappings(connection.getSettings().getDefaultColumnMappings());
+        this.caseSensitive = connection.getSettings().isDefaultCaseSensitive();
 
         paramNameToIdxMap = new HashMap<>();
         parameters = new HashMap<>();
 
-        parsedQuery = connection.getSql2o().getQuirks().getSqlParameterParsingStrategy().parseSql(queryText, paramNameToIdxMap);
+        parsedQuery = connection.getSettings().getQuirks().getSqlParameterParsingStrategy().parseSql(queryText, paramNameToIdxMap);
     }
 
     // ------------------------------------------------
@@ -181,7 +181,7 @@ public class Query implements AutoCloseable {
 
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, convertedValue);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, convertedValue);
             }
         });
 
@@ -208,7 +208,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final InputStream value){
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -218,7 +218,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final int value){
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -228,7 +228,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final Integer value) {
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -238,7 +238,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final long value){
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -248,7 +248,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final Long value){
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -258,7 +258,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final String value) {
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -268,7 +268,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final Timestamp value){
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -278,7 +278,7 @@ public class Query implements AutoCloseable {
     public Query addParameter(String name, final Time value) {
         addParameterInternal(name, new ParameterSetter() {
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
 
@@ -289,7 +289,7 @@ public class Query implements AutoCloseable {
         addParameterInternal(name, new ParameterSetter() {
             @Override
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
         return this;
@@ -299,7 +299,7 @@ public class Query implements AutoCloseable {
         addParameterInternal(name, new ParameterSetter() {
             @Override
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
         return this;
@@ -309,7 +309,7 @@ public class Query implements AutoCloseable {
         addParameterInternal(name, new ParameterSetter() {
             @Override
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
-                getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, value);
+                getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, value);
             }
         });
         return this;
@@ -343,10 +343,10 @@ public class Query implements AutoCloseable {
             @Override
             public void setParameter(int paramIdx, PreparedStatement statement) throws SQLException {
                 if(values.length == 0) {
-                    getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx, (Object) null);
+                    getConnection().getSettings().getQuirks().setParameter(statement, paramIdx, (Object) null);
                 } else {
                     for (Object value : values) {
-                        getConnection().getSql2o().getQuirks().setParameter(statement, paramIdx++, value);
+                        getConnection().getSettings().getQuirks().setParameter(statement, paramIdx++, value);
                     }
                 }
             }
@@ -521,7 +521,7 @@ public class Query implements AutoCloseable {
     }
 
     private <T> ResultSetHandlerFactory<T> newResultSetHandlerFactory(Class<T> returnType) {
-        final Quirks quirks = getConnection().getSql2o().getQuirks();
+        final Quirks quirks = getConnection().getSettings().getQuirks();
         ResultSetHandlerFactoryBuilder builder = getResultSetHandlerFactoryBuilder();
         if(builder==null) builder=new DefaultResultSetHandlerFactoryBuilder();
         builder.setAutoDeriveColumnNames(this.autoDeriveColumnNames);
@@ -541,7 +541,7 @@ public class Query implements AutoCloseable {
      * @return iterable results
      */
     public <T> ResultSetIterable<T> executeAndFetchLazy(final ResultSetHandlerFactory<T> resultSetHandlerFactory) {
-        final Quirks quirks = getConnection().getSql2o().getQuirks();
+        final Quirks quirks = getConnection().getSettings().getQuirks();
         return new ResultSetIterableBase<T>() {
             public Iterator<T> iterator() {
                 return new PojoResultSetIterator<>(rs, isCaseSensitive(), quirks, resultSetHandlerFactory);
@@ -626,7 +626,7 @@ public class Query implements AutoCloseable {
 
         lt.setRows(new ResultSetIterableBase<Row>() {
             public Iterator<Row> iterator() {
-                return new TableResultSetIterator(rs, isCaseSensitive(), getConnection().getSql2o().getQuirks(), lt);
+                return new TableResultSetIterator(rs, isCaseSensitive(), getConnection().getSettings().getQuirks(), lt);
             }
         });
 
@@ -704,7 +704,7 @@ public class Query implements AutoCloseable {
     }
 
     private Quirks getQuirks() {
-        return this.connection.getSql2o().getQuirks();
+        return this.connection.getSettings().getQuirks();
     }
 
     public <V> V executeScalar(Class<V> returnType){

--- a/core/src/main/java/org/sql2o/ReconnectableConnection.java
+++ b/core/src/main/java/org/sql2o/ReconnectableConnection.java
@@ -1,0 +1,57 @@
+package org.sql2o;
+
+import org.sql2o.connectionsources.ConnectionSource;
+
+import java.sql.SQLException;
+
+import static java.util.Objects.requireNonNull;
+
+
+class ReconnectableConnection extends BaseConnection {
+
+    private final ConnectionSource connectionSource;
+
+
+    ReconnectableConnection(Settings settings, ConnectionSource connectionSource, boolean autoClose) {
+        super(settings, autoClose);
+        this.connectionSource = requireNonNull(connectionSource, "connectionSource can't be null");
+        createConnection();
+    }
+
+    @Override
+    public Query createQuery(String queryText, boolean returnGeneratedKeys){
+
+        try {
+            if (jdbcConnection.isClosed()){
+                createConnection();
+            }
+        } catch (SQLException e) {
+            throw new Sql2oException("Error creating connection", e);
+        }
+
+        return new Query(this, queryText, returnGeneratedKeys);
+    }
+
+    @Override
+    public Query createQuery(String queryText, String... columnNames) {
+        try {
+            if (jdbcConnection.isClosed()) {
+                createConnection();
+            }
+        } catch(SQLException e) {
+            throw new Sql2oException("Error creating connection", e);
+        }
+
+        return new Query(this, queryText, columnNames);
+    }
+
+    private void createConnection(){
+        try{
+            this.jdbcConnection = connectionSource.getConnection();
+        }
+        catch(Exception ex){
+            throw new Sql2oException("Could not acquire a connection from DataSource - " + ex.getMessage(), ex);
+        }
+    }
+
+}

--- a/core/src/main/java/org/sql2o/Settings.java
+++ b/core/src/main/java/org/sql2o/Settings.java
@@ -30,9 +30,7 @@ public class Settings {
         this.defaultCaseSensitive = defaultCaseSensitive;
     }
 
-    public Settings() {
-        this(new NoQuirks(), new HashMap<String, String>(), false);
-    }
+    public static Settings defaults = new Settings(new NoQuirks(), new HashMap<String, String>(), false);
 
     public Quirks getQuirks() {
         return quirks;

--- a/core/src/main/java/org/sql2o/Settings.java
+++ b/core/src/main/java/org/sql2o/Settings.java
@@ -1,0 +1,88 @@
+package org.sql2o;
+
+import org.sql2o.quirks.NoQuirks;
+import org.sql2o.quirks.Quirks;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Settings class that stores all tunable parameters that are used in Sql2o.
+ * Objects of this class are immutable, to change something please use {@code with*} methods
+ * that will create new instances of this class
+ *
+ * Created by nickl on 20.01.17.
+ */
+public class Settings {
+
+    private Quirks quirks;
+    private Map<String, String> defaultColumnMappings;
+    private boolean defaultCaseSensitive;
+
+
+    public Settings(Quirks quirks, Map<String, String> defaultColumnMappings, boolean defaultCaseSensitive) {
+        this.quirks = requireNonNull(quirks, "quirks can't be null");
+        this.defaultColumnMappings = Collections.unmodifiableMap(requireNonNull(defaultColumnMappings, "defaultColumnMappings can't be null"));
+        this.defaultCaseSensitive = defaultCaseSensitive;
+    }
+
+    public Settings() {
+        this(new NoQuirks(), new HashMap<String, String>(), false);
+    }
+
+    public Quirks getQuirks() {
+        return quirks;
+    }
+
+    /**
+     * Gets the default column mappings Map. column mappings added to this Map are always available when Sql2o attempts
+     * to map between result sets and object instances.
+     * @return  The {@link Map<String, String>} instance, which Sql2o internally uses to map column names with property
+     * names.
+     */
+    public Map<String, String> getDefaultColumnMappings() {
+        return defaultColumnMappings;
+    }
+
+    /**
+     * Gets value indicating if this instance of Sql2o is case sensitive when mapping between columns names and property
+     * names.
+     * @return
+     */
+    public boolean isDefaultCaseSensitive() {
+        return defaultCaseSensitive;
+    }
+
+
+    /**
+     * Creates a new instance of Settings class with updated {@code defaultColumnMappings} parameter
+     * @param defaultColumnMappings new column mapping to use
+     * @return new instance of Settings
+     */
+    public Settings withDefaultColumnMappings(Map<String, String> defaultColumnMappings){
+       return new Settings(quirks, defaultColumnMappings, defaultCaseSensitive);
+    }
+
+    /**
+     * Creates a new instance of Settings class with updated {@code defaultCaseSensitive} parameter
+     * @param defaultCaseSensitive new case sensitivity to use
+     * @return new instance of Settings
+     */
+    public Settings withDefaultCaseSensitive(boolean defaultCaseSensitive){
+       return new Settings(quirks, defaultColumnMappings, defaultCaseSensitive);
+    }
+
+    /**
+     * Creates a new instance of Settings class with updated {@code quirks} parameter
+     * @param quirks new quirks to use
+     * @return new instance of Settings
+     */
+    public Settings withQuirks(Quirks quirks){
+       return new Settings(quirks, defaultColumnMappings, defaultCaseSensitive);
+    }
+
+}

--- a/core/src/main/java/org/sql2o/Sql2o.java
+++ b/core/src/main/java/org/sql2o/Sql2o.java
@@ -326,6 +326,10 @@ public class Sql2o {
      * method or the {@link org.sql2o.Connection#rollback()} method to close the transaction. Use proper try-catch logic.
      * @param connectionSource the {@link ConnectionSource} implementation substitution,
      *                         that will be used instead of one from {@link Sql2o} instance.
+     *                         <b>Note:</b> if connectionSource is null then connectionSource
+     *                         from {@link Sql2o} instance will be used that by default
+     *                         means execution in dedicated transaction. Make sure in calling code that
+     *                         your are not passing the {@code null} value if you dont expect this behaviour.
      * @return the {@link Connection} instance to use to run statements in the transaction.
      */
     public Connection beginTransaction(ConnectionSource connectionSource) {

--- a/core/src/main/java/org/sql2o/Sql2o.java
+++ b/core/src/main/java/org/sql2o/Sql2o.java
@@ -249,6 +249,12 @@ public class Sql2o {
      * @return instance of the {@link org.sql2o.Connection} class.
      */
     public Connection open(ConnectionSource connectionSource) {
+        if(connectionSource == null)
+        {
+            checkConnectionSource("open with null connectionSource");
+            connectionSource = getConnectionSource();
+        }
+
         return new ReconnectableConnection(this.settings, connectionSource, false);
     }
 
@@ -356,6 +362,11 @@ public class Sql2o {
      * @return the {@link Connection} instance to use to run statements in the transaction.
      */
     public Connection beginTransaction(ConnectionSource connectionSource, int isolationLevel) {
+        if(connectionSource == null)
+        {
+            checkConnectionSource("beginTransaction with null connectionSource");
+            connectionSource = getConnectionSource();
+        }
 
         Connection connection = new ReconnectableConnection(this.settings, connectionSource, false);
 

--- a/core/src/test/java/org/sql2o/ConnectionTest.java
+++ b/core/src/test/java/org/sql2o/ConnectionTest.java
@@ -33,7 +33,7 @@ public class ConnectionTest extends TestCase {
                 return false;
             }
         });
-        org.sql2o.Connection cn = new org.sql2o.Connection(sql2o.getSettings(), sql2o.getConnectionSource(),false);
+        org.sql2o.Connection cn = new ReconnectableConnection(sql2o.getSettings(), sql2o.getConnectionSource(),false);
         cn.createQueryWithParams("select :p1 name, :p2 age", "Dmitry Alexandrov", 35).buildPreparedStatement();
 
         verify(dataSource,times(1)).getConnection();

--- a/core/src/test/java/org/sql2o/ConnectionTest.java
+++ b/core/src/test/java/org/sql2o/ConnectionTest.java
@@ -33,7 +33,7 @@ public class ConnectionTest extends TestCase {
                 return false;
             }
         });
-        org.sql2o.Connection cn = new org.sql2o.Connection(sql2o,false);
+        org.sql2o.Connection cn = new org.sql2o.Connection(sql2o.getSettings(), sql2o.getConnectionSource(),false);
         cn.createQueryWithParams("select :p1 name, :p2 age", "Dmitry Alexandrov", 35).buildPreparedStatement();
 
         verify(dataSource,times(1)).getConnection();

--- a/core/src/test/java/org/sql2o/Sql2oTest.java
+++ b/core/src/test/java/org/sql2o/Sql2oTest.java
@@ -211,7 +211,7 @@ public class Sql2oTest extends BaseMemDbTest {
 
 
         // test defaultCaseSensitive;
-        sql2o.setDefaultCaseSensitive(false);
+        sql2o.setSettings(sql2o.getSettings().withDefaultCaseSensitive(false));
         List<CIEntity> ciEntities2 = sql2o.createQuery("select * from testCI").executeAndFetch(CIEntity.class);
         assertTrue(ciEntities2.size() == 20);
     }
@@ -469,10 +469,10 @@ public class Sql2oTest extends BaseMemDbTest {
                 .createQuery("insert into test_rollback_table(value) values (:val)")
                 .addParameter("val", "something")
                 .executeUpdate()
-                .commit()
+                .commit();
 
                         // insert something else, and roll it back.
-                .beginTransaction()
+        sql2o.beginTransaction()
                 .createQuery("insert into test_rollback_table(value) values (:val)")
                 .addParameter("val", "something to rollback")
                 .executeUpdate()
@@ -514,7 +514,7 @@ public class Sql2oTest extends BaseMemDbTest {
         defaultColMaps.put("caption", "text");
         defaultColMaps.put("theTime", "time");
 
-        sql2o1.setDefaultColumnMappings(defaultColMaps);
+        sql2o1.setSettings(sql2o1.getSettings().withDefaultColumnMappings(defaultColMaps));
 
         Entity entity = sql2o1.createQuery("select 1 as id, 'something' as caption, cast('2011-01-01' as date) as theTime from (values(0))").executeAndFetchFirst(Entity.class);
 

--- a/core/src/test/java/org/sql2o/issues/H2Tests.java
+++ b/core/src/test/java/org/sql2o/issues/H2Tests.java
@@ -55,7 +55,7 @@ public class H2Tests {
             put(DateTime.class, new DateTimeConverter(DateTimeZone.getDefault()));
         }}));
 
-        assertThat(sql2o.getQuirks(), is(instanceOf(NoQuirks.class)));
+        assertThat(sql2o.getSettings().getQuirks(), is(instanceOf(NoQuirks.class)));
 
         try (Connection connection = sql2o.open()) {
             int val = connection.createQuery("select 42").executeScalar(Integer.class);
@@ -75,7 +75,7 @@ public class H2Tests {
 
         Sql2o sql2o = new Sql2o(ds);
 
-        assertThat(sql2o.getQuirks(), is(instanceOf(H2Quirks.class)));
+        assertThat(sql2o.getSettings().getQuirks(), is(instanceOf(H2Quirks.class)));
     }
 
     /**

--- a/extensions/db2/pom.xml
+++ b/extensions/db2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.sql2o.extensions</groupId>
         <artifactId>extensions-parent</artifactId>
-        <version>1.6.0-RC4-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/extensions/oracle-joda-time/pom.xml
+++ b/extensions/oracle-joda-time/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.sql2o.extensions</groupId>
         <artifactId>extensions-parent</artifactId>
-        <version>1.6.0-RC4-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.sql2o.extensions</groupId>
             <artifactId>sql2o-oracle</artifactId>
-            <version>1.6.0-RC4-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/oracle/pom.xml
+++ b/extensions/oracle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.sql2o.extensions</groupId>
         <artifactId>extensions-parent</artifactId>
-        <version>1.6.0-RC4-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.sql2o</groupId>
         <artifactId>sql2o-parent</artifactId>
-        <version>1.6.0-RC4-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/extensions/postgres/pom.xml
+++ b/extensions/postgres/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.sql2o.extensions</groupId>
         <artifactId>extensions-parent</artifactId>
-        <version>1.6.0-RC4-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.sql2o</groupId>
     <artifactId>sql2o-parent</artifactId>
     <name>Sql2o parent</name>
-    <version>1.6.0-RC4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <description>
         Easy database query library
     </description>


### PR DESCRIPTION
Following suggestions mentioned in #264 I've prepared a proposal for some changes that could be done in 2.0 version.

At first I've extracted an immutable `Settings` class to store column mappings, case sensitivity and maybe later `ResultSetHandlerFactoryBuilder`. This allowed not to store `Sql2o` instance in `Connections`.

At second I've converted `Connection` class to an interface with two package-private implementations:

  1. `BaseConnection` an implementation that simply holds JDBC connection
  2. `ReconnectableConnection` a sublclass of `BaseConnection` which is able to reopen closed JDBC connection and is default implementation, which is used by `Sql2o`. (but actually I don't like this idea of reopening)

I've added a `Sql2o.wrap(java.sql.Connection jdbcConnection) `method to simply wrap `java.sql.Connection` and return `BaseConnection` implementation:

```java
Sql2o sql2oWrapper = new Sql2o(sql2o.getSettings());

java.sql.Connection jdbc = ((DataSourceConnectionSource) sql2o.getConnectionSource()).getDataSource().getConnection();

try (Connection connection = sql2oWrapper.wrap(jdbc)) {
    connection.createQuery("create table testWrappingJDBC(id int primary key, val varchar(20) not null)")
            .executeUpdate();

    String sql = "insert into testWrappingJDBC(id, val) values (:id, :val);";
    connection.createQuery(sql).addParameter("id", 1).addParameter("val", "foo").executeUpdate();

    int count1 = connection.createQuery("select count(*) from testWrappingJDBC").executeAndFetchFirst(Integer.class);
    assertThat(count1, is(equalTo(1)));

    String sql2 = "insert into testWrappingJDBC(id, val) values (:id, :val);";
    connection.createQuery(sql2).addParameter("id", 2).addParameter("val", "bar").executeUpdate();

    int count2 = connection.createQuery("select count(*) from testWrappingJDBC").executeAndFetchFirst(Integer.class);
    assertThat(count2, is(equalTo(2)));

}
```

In addition to converting to interface it makes another **breaking** change: `commit` and `rollback` methods of `Connection` can't return `Sql2o` instance anymore, because connection doesn't hold it.
