### PR TITLE
CDI's dependency injection support

### DIFF
--- a/core/src/main/java/org/sql2o/Connection.java
+++ b/core/src/main/java/org/sql2o/Connection.java
@@ -58,6 +58,13 @@ public class Connection implements AutoCloseable, Closeable {
 
     final boolean autoClose;
 
+    /**
+     * Adds CDI's dependency injection support
+     */
+    Connection() {
+        this.autoClose = false;
+    }
+    
     Connection(Sql2o sql2o, boolean autoClose) {
         this(sql2o, null, autoClose);
     }

--- a/core/src/main/java/org/sql2o/Sql2o.java
+++ b/core/src/main/java/org/sql2o/Sql2o.java
@@ -4,6 +4,7 @@ import org.sql2o.connectionsources.DataSourceConnectionSource;
 import org.sql2o.connectionsources.ConnectionSource;
 import org.sql2o.logging.LocalLoggerFactory;
 import org.sql2o.logging.Logger;
+import org.sql2o.quirks.NoQuirks;
 import org.sql2o.quirks.Quirks;
 import org.sql2o.quirks.QuirksDetector;
 
@@ -35,6 +36,13 @@ public class Sql2o {
 
     private final static Logger logger = LocalLoggerFactory.getLogger(Sql2o.class);
 
+    /**
+     * Adds CDI's dependency injection support
+     */
+    Sql2o() {
+        quirks = new NoQuirks();
+    }
+    
     public Sql2o(String jndiLookup) {
         this(JndiDataSource.getJndiDatasource(jndiLookup));
     }


### PR DESCRIPTION
I tried using dependency injection (Java EE's CDI) with Sql2o and didn't work. It would be a very useful feature.

Just add a no-arg constructor in Sql2o and Connection classes. I did it and decided to share.