### PR TITLE
Add Query.ignoreColumn()

### DIFF
--- a/core/src/main/java/org/sql2o/DefaultResultSetHandlerFactory.java
+++ b/core/src/main/java/org/sql2o/DefaultResultSetHandlerFactory.java
@@ -190,6 +190,10 @@ public class DefaultResultSetHandlerFactory<T> implements ResultSetHandlerFactor
         getters = new Getter[columnCount + 1];   // getters[0] is always null
         for (int i = 1; i <= columnCount; i++) {
             String colName = quirks.getColumnName(meta, i);
+            if( metadata.getIgnoredColumns().contains( colName.toLowerCase() ) ) {
+                continue;
+            }
+
             // behavior change: do not throw if POJO contains less properties
             getters[i] = getGetter(quirks, colName, metadata);
 
@@ -203,7 +207,9 @@ public class DefaultResultSetHandlerFactory<T> implements ResultSetHandlerFactor
         setters = new Setter[columnCount + 1];   // setters[0] is always null
         for (int i = 1; i <= columnCount; i++) {
             String colName = quirks.getColumnName(meta, i);
-
+            if( metadata.getIgnoredColumns().contains( colName.toLowerCase() ) ) {
+                continue;
+            }
             setters[i] = getSetter(quirks, colName, metadata);
 
             // If more than 1 column is fetched (we cannot fall back to executeScalar),

--- a/core/src/main/java/org/sql2o/DefaultResultSetHandlerFactoryBuilder.java
+++ b/core/src/main/java/org/sql2o/DefaultResultSetHandlerFactoryBuilder.java
@@ -4,6 +4,7 @@ import org.sql2o.quirks.Quirks;
 import org.sql2o.reflection.PojoMetadata;
 
 import java.util.Map;
+import java.util.Set;
 
 public class DefaultResultSetHandlerFactoryBuilder implements ResultSetHandlerFactoryBuilder {
     private boolean caseSensitive;
@@ -11,6 +12,12 @@ public class DefaultResultSetHandlerFactoryBuilder implements ResultSetHandlerFa
     private boolean throwOnMappingError;
     private Map<String, String> columnMappings;
     private Quirks quirks;
+    private Set<String> ignoredColumns;
+
+    @Override
+    public void setIgnoredColumns( Set<String> ignoredColumns ) {
+        this.ignoredColumns = ignoredColumns;
+    }
 
     public boolean isCaseSensitive() {
         return caseSensitive;
@@ -58,7 +65,7 @@ public class DefaultResultSetHandlerFactoryBuilder implements ResultSetHandlerFa
 
     @SuppressWarnings("unchecked")
     public <T> ResultSetHandlerFactory<T> newFactory(Class<T> clazz) {
-        PojoMetadata pojoMetadata = new PojoMetadata(clazz, caseSensitive, autoDeriveColumnNames, columnMappings, throwOnMappingError);
+        PojoMetadata pojoMetadata = new PojoMetadata(clazz, caseSensitive, autoDeriveColumnNames, columnMappings, throwOnMappingError, ignoredColumns);
         return new DefaultResultSetHandlerFactory(pojoMetadata, quirks);
     }
 

--- a/core/src/main/java/org/sql2o/Query.java
+++ b/core/src/main/java/org/sql2o/Query.java
@@ -27,6 +27,7 @@ public class Query implements AutoCloseable {
     private final static Logger logger = LocalLoggerFactory.getLogger(Query.class);
 
     private Connection connection;
+    private Set<String> ignoredColumns = new HashSet<>();
     private Map<String, String> caseSensitiveColumnMappings;
     private Map<String, String> columnMappings;
     private PreparedStatement preparedStatement = null;
@@ -315,6 +316,11 @@ public class Query implements AutoCloseable {
         return this;
     }
 
+    public Query ignoreColumn( String colName ) {
+        ignoredColumns.add( colName.toLowerCase() );
+        return this;
+    }
+
     /**
      * Set an array parameter.<br>
      * For example:
@@ -529,6 +535,7 @@ public class Query implements AutoCloseable {
         builder.setColumnMappings(this.getColumnMappings());
         builder.setQuirks(quirks);
         builder.throwOnMappingError(this.throwOnMappingFailure);
+        builder.setIgnoredColumns( ignoredColumns );
         return builder.newFactory(returnType);
     }
 

--- a/core/src/main/java/org/sql2o/ResultSetHandlerFactoryBuilder.java
+++ b/core/src/main/java/org/sql2o/ResultSetHandlerFactoryBuilder.java
@@ -3,6 +3,7 @@ package org.sql2o;
 import org.sql2o.quirks.Quirks;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created with IntelliJ IDEA.
@@ -33,4 +34,6 @@ public interface ResultSetHandlerFactoryBuilder {
     void setQuirks(Quirks quirksMode);
 
     <E> ResultSetHandlerFactory<E> newFactory(Class<E> clazz);
+
+    void setIgnoredColumns( Set<String> ignoredColumns );
 }

--- a/core/src/main/java/org/sql2o/reflection/Pojo.java
+++ b/core/src/main/java/org/sql2o/reflection/Pojo.java
@@ -58,7 +58,7 @@ public class Pojo {
                 return getter.getProperty(this.object);
             }
 
-            PojoMetadata subMetadata = new PojoMetadata(getter.getType(), this.caseSensitive, this.metadata.isAutoDeriveColumnNames(), this.metadata.getColumnMappings(), this.metadata.throwOnMappingFailure);
+            PojoMetadata subMetadata = new PojoMetadata(getter.getType(), this.caseSensitive, this.metadata.isAutoDeriveColumnNames(), this.metadata.getColumnMappings(), this.metadata.throwOnMappingFailure, this.metadata.getIgnoredColumns());
             Pojo subPojo = new Pojo(subMetadata, this.caseSensitive, subValue);
 
             return subPojo.getProperty(newPath, quirks);
@@ -105,7 +105,7 @@ public class Pojo {
                 setter.setProperty(this.object, subValue);
             }
             
-            PojoMetadata subMetadata = new PojoMetadata(setter.getType(), this.caseSensitive, this.metadata.isAutoDeriveColumnNames(), this.metadata.getColumnMappings(), this.metadata.throwOnMappingFailure);
+            PojoMetadata subMetadata = new PojoMetadata(setter.getType(), this.caseSensitive, this.metadata.isAutoDeriveColumnNames(), this.metadata.getColumnMappings(), this.metadata.throwOnMappingFailure, this.metadata.getIgnoredColumns());
             Pojo subPojo = new Pojo(subMetadata, this.caseSensitive, subValue);
             subPojo.setProperty(newPath, value, quirks);
         }

--- a/core/src/main/java/org/sql2o/reflection/PojoMetadata.java
+++ b/core/src/main/java/org/sql2o/reflection/PojoMetadata.java
@@ -1,17 +1,17 @@
 package org.sql2o.reflection;
 
+import org.sql2o.Sql2oException;
+import org.sql2o.tools.AbstractCache;
+import org.sql2o.tools.UnderscoreToCamelCase;
+
+import javax.persistence.Column;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.persistence.Column;
-
-import org.sql2o.Sql2oException;
-import org.sql2o.tools.AbstractCache;
-import org.sql2o.tools.UnderscoreToCamelCase;
+import java.util.Set;
 
 /**
  * Stores metadata for a POJO.
@@ -28,6 +28,8 @@ public class PojoMetadata {
     private boolean autoDeriveColumnNames;
     public final boolean throwOnMappingFailure;
     private Class clazz;
+
+    private final Set<String> ignoredColumns;
 
     public boolean isCaseSensitive() {
         return caseSensitive;
@@ -59,11 +61,12 @@ public class PojoMetadata {
         return result;
     }
 
-    public PojoMetadata(Class clazz, boolean caseSensitive, boolean autoDeriveColumnNames, Map<String, String> columnMappings, boolean throwOnMappingError) {
+    public PojoMetadata(Class clazz, boolean caseSensitive, boolean autoDeriveColumnNames, Map<String, String> columnMappings, boolean throwOnMappingError, Set<String> ignoredColumns ) {
         this.caseSensitive = caseSensitive;
         this.autoDeriveColumnNames = autoDeriveColumnNames;
         this.clazz = clazz;
         this.columnMappings = columnMappings == null ? Collections.<String,String>emptyMap() : columnMappings;
+        this.ignoredColumns = ignoredColumns == null ? Collections.<String>emptySet() : ignoredColumns;
 
         this.propertyInfo = getPropertyInfoThroughCache();
         this.throwOnMappingFailure = throwOnMappingError;
@@ -72,6 +75,10 @@ public class PojoMetadata {
 
     public ObjectConstructor getObjectConstructor() {
         return propertyInfo.objectConstructor;
+    }
+
+    public Set<String> getIgnoredColumns() {
+        return ignoredColumns;
     }
 
     private PropertyAndFieldInfo getPropertyInfoThroughCache() {

--- a/core/src/test/java/org/sql2o/issues/IssuesTest.java
+++ b/core/src/test/java/org/sql2o/issues/IssuesTest.java
@@ -361,12 +361,30 @@ public class IssuesTest {
 
             try {
                 Pojo pojo = connection.createQuery(sql).executeAndFetchFirst(Pojo.class);
-                fail("Expeced an exception to be thrown");
+                fail("Expected an exception to be thrown");
             } catch(Sql2oException e) {
                 assertEquals("Could not map VAL2 to any property.", e.getMessage());
             }
 
             Pojo pojo = connection.createQuery(sql).throwOnMappingFailure(false).executeAndFetchFirst(Pojo.class);
+
+            assertEquals(1, pojo.id);
+            assertEquals("foo", pojo.val1);
+        }
+    }
+
+    @Test
+    public void testIgnoreSpecificColumnMapping() {
+        String sql = "select 1 id, 'foo' val1, 'bar' val2 from (values(0))";
+
+        class Pojo{
+            public int id;
+            public String val1;
+        }
+
+        try (Connection connection = sql2o.open()) {
+
+            Pojo pojo = connection.createQuery(sql).ignoreColumn("val2").executeAndFetchFirst(Pojo.class);
 
             assertEquals(1, pojo.id);
             assertEquals("foo", pojo.val1);

--- a/core/src/test/java/org/sql2o/reflect/ReadColumnAnnotationTest.java
+++ b/core/src/test/java/org/sql2o/reflect/ReadColumnAnnotationTest.java
@@ -1,13 +1,12 @@
 package org.sql2o.reflect;
 
-import javax.persistence.Column;
-
+import com.google.common.collect.ImmutableMap;
+import junit.framework.TestCase;
 import org.junit.Test;
 import org.sql2o.reflection.PojoMetadata;
 
-import com.google.common.collect.ImmutableMap;
-
-import junit.framework.TestCase;
+import javax.persistence.Column;
+import java.util.Collections;
 
 @SuppressWarnings("unused")
 public class ReadColumnAnnotationTest extends TestCase {
@@ -53,7 +52,7 @@ public class ReadColumnAnnotationTest extends TestCase {
     }
 
     private PojoMetadata newPojoMetadata(Class<?> clazz) {
-        return new PojoMetadata(clazz, false, false, ImmutableMap.<String, String> of(), true);
+        return new PojoMetadata(clazz, false, false, ImmutableMap.<String, String> of(), true, Collections.<String>emptySet());
     }
 
     private static class NoAnnotation {


### PR DESCRIPTION
Add ability to ignore specific fields when mapping POJOs.  The blanket "ignore mapping exceptions" option that was added actually hid defects since primitive values in the POJO were being initialized with incorrect values