### PR TITLE
reset autocommit state when closing the connection

### DIFF
--- a/core/src/test/java/org/sql2o/ConnectionTransactionTest.java
+++ b/core/src/test/java/org/sql2o/ConnectionTransactionTest.java
@@ -1,0 +1,42 @@
+package org.sql2o;
+
+import org.junit.Test;
+import org.sql2o.quirks.NoQuirks;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Test to check if the autoCommit state has been reset upon close
+ */
+public class ConnectionTransactionTest {
+
+    @Test
+    public void beginTransaction() throws Exception {
+        final DataSource dataSource = mock(DataSource.class);
+        final java.sql.Connection connectionMock = mock(Connection.class);
+
+        // mocked behaviour
+        when(dataSource.getConnection()).thenReturn(connectionMock);
+        when(connectionMock.getAutoCommit()).thenReturn(true);
+        when(connectionMock.isClosed()).thenReturn(false);
+
+        final Sql2o sql2o = new Sql2o(dataSource, new NoQuirks());
+        final org.sql2o.Connection sql2oConnection = sql2o.beginTransaction();
+        sql2oConnection.close();
+
+        // Verifications
+        verify(dataSource).getConnection();
+        verify(connectionMock, atLeastOnce()).getAutoCommit();
+        // called on beginTransaction
+        verify(connectionMock, times(1)).setAutoCommit(eq(false));
+        // called on closeConnection to reset autocommit state
+        verify(connectionMock, times(1)).setAutoCommit(eq(true));
+        verify(connectionMock, atLeastOnce()).setTransactionIsolation(anyInt());
+        verify(connectionMock, times(1)).isClosed();
+        verify(connectionMock, times(1)).close();
+        verifyNoMoreInteractions(connectionMock, dataSource);
+    }
+}


### PR DESCRIPTION
Our production system is set up with a connection pool that sets the AutoCommit property to true. For some reason had one developer used explicit transactions using Sql2o.beginTransaction which sets AutoCommit to false.

Unfortunately the AutoCommit flag is not reset on "commit" or close which caused problems with the next database operation that got the same recycled connection from the pool with the AutoCommit property still set to "false". 

Personally I prefer to always setting autocommit to false and use explicit transactions where needed, but as this is not always the case Sql2o should reset the behaviour before "closing" the connection (i.e returning it to the pool for reeuse)