### PR TITLE
Improvement for executeAndFetchTable().asList()

### DIFF
--- a/core/src/main/java/org/sql2o/data/Row.java
+++ b/core/src/main/java/org/sql2o/data/Row.java
@@ -19,6 +19,7 @@ public class Row {
     private final boolean isCaseSensitive;
     private final Quirks quirks;
     private final Map<String, Integer> columnNameToIdxMap;
+    private Map<String, Object> asMap;
 
     public Row(Map<String, Integer> columnNameToIdxMap, int columnCnt, boolean isCaseSensitive, Quirks quirks) {
         this.columnNameToIdxMap = columnNameToIdxMap;
@@ -144,14 +145,17 @@ public class Row {
      * View row as a simple map.
      */
     public Map<String, Object> asMap() {
-        Map map = new HashMap();
-        Set<String> keys = columnNameToIdxMap.keySet();
-        Iterator iterator = keys.iterator();
-        while (iterator.hasNext()) {
-            String colum = iterator.next().toString();
-            int index = columnNameToIdxMap.get(colum);
-            map.put(colum, values[index]);
+
+        if(null == this.asMap){
+            this.asMap = new HashMap<>();
+            Set<String> keys = columnNameToIdxMap.keySet();
+            Iterator iterator = keys.iterator();
+            while (iterator.hasNext()) {
+                String colum = iterator.next().toString();
+                int index = columnNameToIdxMap.get(colum);
+                this.asMap.put(colum, values[index]);
+            }
         }
-        return map;
+        return this.asMap;
     }
 }

--- a/core/src/main/java/org/sql2o/data/Table.java
+++ b/core/src/main/java/org/sql2o/data/Table.java
@@ -40,6 +40,11 @@ public class Table {
             public int size() {
                 return rows.size();
             }
+
+            @Override
+            public Map<String, Object> remove(int index) {
+                return rows.remove(index).asMap();
+            }
         };
     }
 }


### PR DESCRIPTION
When you use 
`List<Map<String,Object>> ... = con.createQuery(complexSql).executeAndFetchTable().asList()`, you cannot add data in a row of this list. It can sometimes be useful, for example if you have data comming from SQL and you need to merge them with data comming from a file, or other...
Before my change, it was not possible, as the `Map` that represents the SQL row is re-created every time it is accessed.
My change might also make the code faster.

Thanks
