### PR TITLE
Exposing prepared statement fetch size parameter

### DIFF
--- a/core/src/main/java/org/sql2o/Connection.java
+++ b/core/src/main/java/org/sql2o/Connection.java
@@ -38,6 +38,8 @@ public class Connection implements AutoCloseable, Closeable {
 
     private Boolean originalAutoCommit;
 
+    private Boolean autoCommit;
+
     public boolean isRollbackOnException() {
         return rollbackOnException;
     }
@@ -56,6 +58,14 @@ public class Connection implements AutoCloseable, Closeable {
     public Connection setRollbackOnClose(boolean rollbackOnClose) {
         this.rollbackOnClose = rollbackOnClose;
         return this;
+    }
+
+    public Boolean isAutoCommit() {
+        return autoCommit;
+    }
+
+    public void setAutoCommit(boolean autoCommit) {
+        this.autoCommit = autoCommit;
     }
 
     final boolean autoClose;
@@ -305,6 +315,9 @@ public class Connection implements AutoCloseable, Closeable {
         try{
             this.jdbcConnection = connectionSource.getConnection();
             this.originalAutoCommit = jdbcConnection.getAutoCommit();
+            if (autoCommit != null) {
+                jdbcConnection.setAutoCommit(autoCommit);
+            }
         }
         catch(Exception ex){
             throw new Sql2oException("Could not acquire a connection from DataSource - " + ex.getMessage(), ex);

--- a/core/src/main/java/org/sql2o/Query.java
+++ b/core/src/main/java/org/sql2o/Query.java
@@ -52,6 +52,7 @@ public class Query implements AutoCloseable {
     private final Map<String, List<Integer>> paramNameToIdxMap;
     private final Map<String, ParameterSetter> parameters;
     private String parsedQuery;
+    private Integer fetchSize;
     private int maxBatchRecords = 0;
     private int currentBatchRecords = 0;
 
@@ -124,6 +125,15 @@ public class Query implements AutoCloseable {
 
     public Query setName(String name) {
         this.name = name;
+        return this;
+    }
+
+    public Integer getFetchSize() {
+        return fetchSize;
+    }
+
+    public Query setFetchSize(int fetchSize) {
+        this.fetchSize = fetchSize;
         return this;
     }
 
@@ -434,6 +444,9 @@ public class Query implements AutoCloseable {
                     preparedStatement = connection.getJdbcConnection().prepareStatement(parsedQuery, Statement.RETURN_GENERATED_KEYS);
                 } else {
                     preparedStatement = connection.getJdbcConnection().prepareStatement(parsedQuery);
+                }
+                if (fetchSize != null) {
+                    preparedStatement.setFetchSize(fetchSize);
                 }
             } catch(SQLException ex) {
                 throw new Sql2oException(String.format("Error preparing statement - %s", ex.getMessage()), ex);


### PR DESCRIPTION
Work in progess. Need to ensure tests pass.

This exposes the fetch size parameter on the prepared statement. This is needed for Postgres connections, or any connection that does not set a fetch size by default, for large data sets.