### PR TITLE
Skip bridge-methods for POJO-getter/setter #314 

### DIFF
--- a/core/src/main/java/org/sql2o/reflection/PojoMetadata.java
+++ b/core/src/main/java/org/sql2o/reflection/PojoMetadata.java
@@ -115,7 +115,9 @@ public class PojoMetadata {
 
             // prepare methods. Methods will override fields, if both exists.
             for (Method m : theClass.getDeclaredMethods()) {
-
+                if(m.isBridge()) {
+                    continue;
+                }
                 if (m.getName().startsWith("get")) {
                     String propertyName = m.getName().substring(3);
                     if (caseSensitive) {


### PR DESCRIPTION
Bridge-methods are generated by the compiler. In case of #314, getter and setter are created because the class inherited from a parametr. class and the getter/setter work on Object (as in the parent-class, after type erasure). That's why they need to be excluded from the list of methods to choose getters and setters from.