### PR TITLE
Improved precision of BigDecimalConverter

### DIFF
--- a/core/src/main/java/org/sql2o/converters/BigDecimalConverter.java
+++ b/core/src/main/java/org/sql2o/converters/BigDecimalConverter.java
@@ -17,13 +17,13 @@ public class BigDecimalConverter extends NumberConverter<BigDecimal>{
             return (BigDecimal)val;
         }
         else{
-            return BigDecimal.valueOf(val.doubleValue());
+            return new BigDecimal(val.toString());
         }
     }
 
     @Override
     protected BigDecimal convertStringValue(String val) {
-        return BigDecimal.valueOf(Double.parseDouble(val));
+        return new BigDecimal(val);
     }
 
     @Override


### PR DESCRIPTION
> This is generally the preferred way to convert a float or double into a BigDecimal, as it doesn't suffer from the unpredictability of the BigDecimal(double) constructor. 
https://docs.oracle.com/javase/6/docs/api/java/math/BigDecimal.html#BigDecimal(java.lang.String) https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/math/BigDecimal.html#%3Cinit%3E(java.lang.String)